### PR TITLE
응답으로 문자열만 보내는 API를 상대 값만 보내도록 수정

### DIFF
--- a/src/main/java/com/yeojeong/application/domain/board/board/presentation/AuthedBoardController.java
+++ b/src/main/java/com/yeojeong/application/domain/board/board/presentation/AuthedBoardController.java
@@ -66,14 +66,14 @@ public class AuthedBoardController {
     @Operation(summary = "게시글 삭제")
     @ApiResponses(
             value = {
-                    @ApiResponse(responseCode = "200", description = "게시글 삭제 성공"),
+                    @ApiResponse(responseCode = "204", description = "게시글 삭제 성공"),
                     @ApiResponse(responseCode = "400", description = "게시글 삭제 실패"),
                     @ApiResponse(responseCode = "403", description = "권한 없음"),
             }
     )
-    public ResponseEntity<String> delete(@PathVariable("id") Long id){
+    public ResponseEntity<Void> delete(@PathVariable("id") Long id){
         Long memberId = SecurityUtil.getCurrentMemberId();
         boardFacade.delete(id, memberId);
-        return ResponseEntity.ok("게시글 삭제 성공");
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/yeojeong/application/domain/member/email/presentation/dto/SendEmail.java
+++ b/src/main/java/com/yeojeong/application/domain/member/email/presentation/dto/SendEmail.java
@@ -18,14 +18,7 @@ public class SendEmail {
     public record FindPassword(
             String email,
             String password
-    ){
-        public static FindPassword toSendEmail(String email, String password) {
-            return SendEmail.FindPassword.builder()
-                    .email(email)
-                    .password(password)
-                    .build();
-        }
-    }
+    ){}
 
     @Builder
     public record FindUsername(

--- a/src/main/java/com/yeojeong/application/domain/member/member/presentation/AuthedMemberController.java
+++ b/src/main/java/com/yeojeong/application/domain/member/member/presentation/AuthedMemberController.java
@@ -81,18 +81,18 @@ public class AuthedMemberController {
     @Operation(summary = "유저 탈퇴", description = "회원 탈퇴를 진행합니다.")
     @ApiResponses(
             value = {
-                    @ApiResponse(responseCode = "200", description = "유저 탈퇴"),
+                    @ApiResponse(responseCode = "204", description = "유저 탈퇴"),
                     @ApiResponse(responseCode = "400", description = "유저를 찾지 못함"),
                     @ApiResponse(responseCode = "403", description = "권한 없음"),
             }
     )
-    public ResponseEntity<String> deleteByUserId(@Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
-                                                 @Valid @RequestBody MemberRequest.DeleteMember dto) {
+    public ResponseEntity<Void> deleteByUserId(@Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
+                                                 @Valid @RequestBody MemberRequest.Delete dto) {
 
         Long id = SecurityUtil.getCurrentMemberId();
         memberFacade.delete(id, dto);
 
-        return ResponseEntity.ok("유저 탈퇴에 성공했습니다");
+        return ResponseEntity.noContent().build();
     }
 
     @MethodTimer(method = "회원 정보 수정 호출")
@@ -105,8 +105,8 @@ public class AuthedMemberController {
                     @ApiResponse(responseCode = "403", description = "권한 없음"),
             }
     )
-    public ResponseEntity<MemberResponse.FindMember> patchMember(@Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
-                                                                 @Valid @RequestBody MemberRequest.PatchMember dto) {
+    public ResponseEntity<MemberResponse.FindById> patchMember(@Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
+                                                                 @Valid @RequestBody MemberRequest.Patch dto) {
 
         Long id = SecurityUtil.getCurrentMemberId();
         return ResponseEntity.ok(memberFacade.patch(id, dto));

--- a/src/main/java/com/yeojeong/application/domain/member/member/presentation/AuthedMemberController.java
+++ b/src/main/java/com/yeojeong/application/domain/member/member/presentation/AuthedMemberController.java
@@ -81,18 +81,18 @@ public class AuthedMemberController {
     @Operation(summary = "유저 탈퇴", description = "회원 탈퇴를 진행합니다.")
     @ApiResponses(
             value = {
-                    @ApiResponse(responseCode = "200", description = "유저 탈퇴"),
+                    @ApiResponse(responseCode = "204", description = "유저 탈퇴"),
                     @ApiResponse(responseCode = "400", description = "유저를 찾지 못함"),
                     @ApiResponse(responseCode = "403", description = "권한 없음"),
             }
     )
-    public ResponseEntity<String> deleteByUserId(@Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
+    public ResponseEntity<Void> deleteByUserId(@Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
                                                  @Valid @RequestBody MemberRequest.DeleteMember dto) {
 
         Long id = SecurityUtil.getCurrentMemberId();
         memberFacade.delete(id, dto);
 
-        return ResponseEntity.ok("유저 탈퇴에 성공했습니다");
+        return ResponseEntity.noContent().build();
     }
 
     @MethodTimer(method = "회원 정보 수정 호출")

--- a/src/main/java/com/yeojeong/application/domain/member/member/presentation/FindMemberController.java
+++ b/src/main/java/com/yeojeong/application/domain/member/member/presentation/FindMemberController.java
@@ -39,7 +39,7 @@ public class FindMemberController {
                     @ApiResponse(responseCode = "400", description = "입력 값이 잘못됨"),
             }
     )
-    public ResponseEntity<String> findPassword(@Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
+    public ResponseEntity<Void> findPassword(@Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
                                                @Valid @RequestBody MemberRequest.FindPassword dto) {
         String newPassword = memberFacade.findPassword(dto.username(), dto.email());
 
@@ -49,8 +49,7 @@ public class FindMemberController {
                 .build();
 
         memberEmailService.sendFindPassword(sendDto);
-
-        return ResponseEntity.ok("비밀번호 재발급에 성공하였습니다");
+        return ResponseEntity.ok().build();
     }
 
 
@@ -63,7 +62,7 @@ public class FindMemberController {
                     @ApiResponse(responseCode = "400", description = "입력 값이 잘못됨"),
             }
     )
-    public ResponseEntity<String> findUsername(@Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
+    public ResponseEntity<Void> findUsername(@Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
                                                @PathVariable("email") String email) {
 
         String username = memberFacade.findUsernameByEmail(email);
@@ -74,7 +73,6 @@ public class FindMemberController {
                 .build();
 
         memberEmailService.sendFindUsername(sendDto);
-
-        return ResponseEntity.ok("아이디 찾기를 성공하였습니다");
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/yeojeong/application/domain/member/member/presentation/JoinMemberController.java
+++ b/src/main/java/com/yeojeong/application/domain/member/member/presentation/JoinMemberController.java
@@ -51,14 +51,14 @@ public class JoinMemberController {
                 @ApiResponse(responseCode = "401", description = "인증되지 않은 이메일")
         }
     )
-    public ResponseEntity<String> save(@Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
+    public ResponseEntity<Void> save(@Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
                                        @Valid @RequestBody MemberRequest.SaveMember dto) {
 
         if(!memberEmailService.checkAuthedEmail(dto.email()))
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("인증되지 않은 이메일입니다");
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
 
         memberFacade.save(dto);
-        return ResponseEntity.status(HttpStatus.CREATED).body("생성이 완료되었습니다");
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
 
@@ -72,10 +72,10 @@ public class JoinMemberController {
                     @ApiResponse(responseCode = "409", description = "중복됨")
             }
     )
-    public ResponseEntity<String> checkDuplicatedByUsername(@Size(min = 5, max = 30) @PathVariable("username") String username) {
+    public ResponseEntity<Void> checkDuplicatedByUsername(@Size(min = 5, max = 30) @PathVariable("username") String username) {
 
         memberFacade.checkDuplicatedByUsername(username);
-        return ResponseEntity.ok("중복되지 않았습니다");
+        return ResponseEntity.ok().build();
     }
 
     @MethodTimer(method = "닉네임 중복 검사 호출")
@@ -88,10 +88,10 @@ public class JoinMemberController {
                     @ApiResponse(responseCode = "409", description = "중복됨")
             }
     )
-    public ResponseEntity<String> checkDuplicatedByNickname(@Size(min = 1, max = 10) @PathVariable("nickname") String nickname) {
+    public ResponseEntity<Void> checkDuplicatedByNickname(@Size(min = 1, max = 10) @PathVariable("nickname") String nickname) {
 
         memberFacade.checkDuplicatedByNickname(nickname);
-        return ResponseEntity.ok("중복되지 않았습니다");
+        return ResponseEntity.ok().build();
     }
 
 
@@ -105,7 +105,7 @@ public class JoinMemberController {
                     @ApiResponse(responseCode = "409", description = "이메일이 중복 중복됨")
             }
     )
-    public ResponseEntity<String> authedByEmail(@Size(min = 1, max = 50) @Schema(example = "example@naver.com")
+    public ResponseEntity<Void> authedByEmail(@Size(min = 1, max = 50) @Schema(example = "example@naver.com")
                                                 @Email @PathVariable("email") String email) {
 
         memberFacade.checkDuplicatedByEmail(email);
@@ -119,7 +119,7 @@ public class JoinMemberController {
 
         memberEmailService.sendAuthedEmail(dto);
 
-        return ResponseEntity.ok("이메일 인증 코드 전송되었습니다");
+        return ResponseEntity.ok().build();
     }
 
 
@@ -132,14 +132,14 @@ public class JoinMemberController {
                     @ApiResponse(responseCode = "401", description = "이메일 인증 실패")
             }
     )
-    public ResponseEntity<String> authedCheckByEmail(@Size(min = 1, max = 50) @Schema(example = "example@naver.com")
+    public ResponseEntity<Void> authedCheckByEmail(@Size(min = 1, max = 50) @Schema(example = "example@naver.com")
                                                      @Email @PathVariable("email") String email,
 
                                                      @Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
                                                      @RequestBody MemberRequest.EmailAuthedKey takenDto) {
 
         return memberEmailService.checkAuthedKey(email, takenDto.key()) ?
-                ResponseEntity.ok("이메일 인증에 성공하였습니다") :
-                ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("이메일 인증에 실패하였습니다");
+                ResponseEntity.ok().build() :
+                ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
     }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -10,9 +10,3 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: false
-
-  profiles:
-    active: local
-redis:
-  host: localhost
-  port: 6379


### PR DESCRIPTION
1. 응답으로 문자열만 보내는 API를 상대 값만 보내도록 수정했습니다.
2. DELETE에 경우 204를 보내게 수정했습니다.