### PR TITLE
테스트 가능하도록 수정

### DIFF
--- a/src/main/java/com/yeojeong/application/domain/board/board/application/boardfacade/implement/BoardFacadeImpl.java
+++ b/src/main/java/com/yeojeong/application/domain/board/board/application/boardfacade/implement/BoardFacadeImpl.java
@@ -1,5 +1,7 @@
 package com.yeojeong.application.domain.board.board.application.boardfacade.implement;
 
+import com.yeojeong.application.config.exception.RestApiException;
+import com.yeojeong.application.config.exception.handler.ErrorCode;
 import com.yeojeong.application.domain.board.board.application.boardfacade.BoardFacade;
 import com.yeojeong.application.domain.board.board.application.boardservice.BoardService;
 import com.yeojeong.application.domain.board.board.domain.Board;
@@ -34,8 +36,10 @@ public class BoardFacadeImpl implements BoardFacade {
     @Override
     public BoardResponse.FindById update(Long id, Long memberId, BoardRequest.Put dto) {
         Board savedEntity = boardService.findById(id);
+        checkMember(savedEntity, memberId);
+
         Board entity = BoardRequest.Put.toEntity(dto);
-        Board rtnEntity = boardService.update(savedEntity, memberId, entity);
+        Board rtnEntity = boardService.update(savedEntity, entity);
 
         return BoardResponse.FindById.toDto(rtnEntity);
     }
@@ -43,7 +47,9 @@ public class BoardFacadeImpl implements BoardFacade {
     @Override
     public void delete(Long id, Long memberId) {
         Board savedEntity = boardService.findById(id);
-        boardService.delete(savedEntity, memberId);
+        checkMember(savedEntity, memberId);
+
+        boardService.delete(savedEntity);
     }
 
     @Override
@@ -56,5 +62,9 @@ public class BoardFacadeImpl implements BoardFacade {
     public Page<BoardResponse.FindAll> findAll(String searchKeyword, String keyword, String sortKeyword, int page) {
         Page<Board> savedEntityPage = boardService.findAll(searchKeyword, keyword, sortKeyword, page);
         return savedEntityPage.map(BoardResponse.FindAll::toDto);
+    }
+
+    private void checkMember(Board board, Long memberId) {
+        if (!memberId.equals(board.getMember().getId())) throw new RestApiException(ErrorCode.USER_MISMATCH);
     }
 }

--- a/src/main/java/com/yeojeong/application/domain/board/board/application/boardfacade/implement/BoardFacadeImpl.java
+++ b/src/main/java/com/yeojeong/application/domain/board/board/application/boardfacade/implement/BoardFacadeImpl.java
@@ -8,8 +8,12 @@ import com.yeojeong.application.domain.board.board.presentation.dto.BoardRespons
 import com.yeojeong.application.domain.member.member.application.memberservice.MemberService;
 import com.yeojeong.application.domain.member.member.domain.Member;
 import lombok.RequiredArgsConstructor;
+import lombok.Synchronized;
+import org.hibernate.sql.results.graph.collection.internal.SetInitializer;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
+
+import java.io.Serializable;
 
 @Service
 @RequiredArgsConstructor
@@ -43,7 +47,7 @@ public class BoardFacadeImpl implements BoardFacade {
     }
 
     @Override
-    public BoardResponse.FindById findById(Long id, Long memberId) {
+    public synchronized BoardResponse.FindById findById(Long id, Long memberId) {
         Board savedEntity = boardService.findById(id);
         return BoardResponse.FindById.toDto(savedEntity);
     }

--- a/src/main/java/com/yeojeong/application/domain/board/board/application/boardservice/BoardService.java
+++ b/src/main/java/com/yeojeong/application/domain/board/board/application/boardservice/BoardService.java
@@ -6,11 +6,11 @@ import org.springframework.data.domain.Page;
 
 public interface BoardService {
     Board save(Board entity, Member member);
-    Board update(Board entity, Long memberId, Board updateEntity);
+    Board update(Board entity, Board updateEntity);
     Board findById(Long id);
     Page<Board> findByMember(Long memberId, int page);
     Page<Board> findAll(String searchKeyword, String keyword, String sortKeyword, int page);
-    void delete(Board entity, Long memberId);
+    void delete(Board entity);
     void createComment(Board board);
     void deleteComment(Board board);
     void updateComment(Board board);

--- a/src/main/java/com/yeojeong/application/domain/board/board/application/boardservice/implement/BoardServiceImpl.java
+++ b/src/main/java/com/yeojeong/application/domain/board/board/application/boardservice/implement/BoardServiceImpl.java
@@ -36,17 +36,14 @@ public class BoardServiceImpl implements BoardService {
 
     @Override
     @Transactional
-    public Board update(Board entity, Long memberId, Board updateEntity) {
-        if (!memberId.equals(entity.getMember().getId())) throw new RestApiException(ErrorCode.USER_MISMATCH);
-
+    public Board update(Board entity, Board updateEntity) {
         entity.update(updateEntity);
         return boardRepository.save(entity);
     }
 
     @Override
     @Transactional
-    public void delete(Board entity, Long memberId) {
-        if (!memberId.equals(entity.getMember().getId())) throw new RestApiException(ErrorCode.USER_MISMATCH);
+    public void delete(Board entity) {
         boardRepository.delete(entity);
     }
 

--- a/src/main/java/com/yeojeong/application/domain/board/comment/application/commentservice/CommentService.java
+++ b/src/main/java/com/yeojeong/application/domain/board/comment/application/commentservice/CommentService.java
@@ -10,6 +10,6 @@ public interface CommentService {
     Comment save(Comment entity);
     Page<Comment> findByBoardId(Long boardId, int page);
     Page<Comment> findByMemberId(Long memberId, int page);
-    Comment update(Comment entity, Long memberId, Comment updateEntity);
-    void delete(Comment entity, Long memberId);
+    Comment update(Comment entity, Comment updateEntity);
+    void delete(Comment entity);
 }

--- a/src/main/java/com/yeojeong/application/domain/board/comment/application/commentservice/implement/CommentServiceImpl.java
+++ b/src/main/java/com/yeojeong/application/domain/board/comment/application/commentservice/implement/CommentServiceImpl.java
@@ -33,8 +33,7 @@ public class CommentServiceImpl implements CommentService {
 
     @Override
     @Transactional
-    public void delete(Comment entity, Long memberId){
-        if(memberId.equals(entity.getMember().getId())) throw new RestApiException(ErrorCode.USER_MISMATCH);
+    public void delete(Comment entity) {
         commentRepository.delete(entity);
     }
 
@@ -53,10 +52,7 @@ public class CommentServiceImpl implements CommentService {
 
     @Override
     @Transactional
-    public Comment update(Comment entity, Long memberId, Comment updateEntity) {
-        if(!memberId.equals(entity.getMember().getId()))
-            throw new RestApiException(ErrorCode.USER_MISMATCH);
-
+    public Comment update(Comment entity, Comment updateEntity) {
         entity.update(updateEntity);
         return commentRepository.save(entity);
     }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,14 @@
+spring:
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+JWTKey: DevKey12
+EmailPassword: ${emailPassword}
+
+autocomplete:
+  limit: 10
+  suffix: "_suffix"
+  key: "autocomplete"
+  score-key: "autocomplete:score"

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,4 +1,9 @@
 spring:
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://localhost:3306/website
@@ -10,3 +15,12 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: false
+
+JWTKey: DevKey12
+EmailPassword: ${emailPassword}
+
+autocomplete:
+  limit: 10
+  suffix: "_suffix"
+  key: "autocomplete"
+  score-key: "autocomplete:score"

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,16 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+EmailPassword: ${emailPassword}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,19 +1,3 @@
-server:
-  port: 8080
-
 spring:
   profiles:
     active: dev
-  data:
-    redis:
-      host: localhost
-      port: 6379
-
-JWTKey: DevKey12
-EmailPassword: ${emailPassword}
-
-autocomplete:
-  limit: 10
-  suffix: "_suffix"
-  key: "autocomplete"
-  score-key: "autocomplete:score"

--- a/src/test/java/com/yeojeong/application/domain/board/board/application/boardfacade/implement/BoardFacadeImplTest.java
+++ b/src/test/java/com/yeojeong/application/domain/board/board/application/boardfacade/implement/BoardFacadeImplTest.java
@@ -1,0 +1,61 @@
+package com.yeojeong.application.domain.board.board.application.boardfacade.implement;
+
+import com.yeojeong.application.domain.board.board.application.boardservice.BoardService;
+import com.yeojeong.application.domain.board.board.domain.Board;
+import com.yeojeong.application.domain.board.board.presentation.dto.BoardResponse;
+import com.yeojeong.application.domain.board.comment.domain.Comment;
+import com.yeojeong.application.domain.member.member.application.memberservice.MemberService;
+import com.yeojeong.application.domain.member.member.domain.Member;
+import jakarta.persistence.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BoardFacadeImplTest {
+    @InjectMocks
+    private BoardFacadeImpl boardFacadeImpl;
+
+    @Mock
+    private BoardService boardService;
+
+    @Mock
+    private MemberService memberService;
+
+    @Test
+    @DisplayName("조회수 동시성 테스트")
+    void test1() {
+        Long boardId = 1L;
+        Long memberId = 1L;
+
+        Board mockBoard = Board.builder()
+                .id(boardId)
+                .locationName("locationName")
+                .formattedAddress("formattedAddress")
+                .longitude("longitude")
+                .latitude("latitude")
+                .title("title")
+                .body("body")
+                .view(0)
+                .member(new Member())
+                .comments(new ArrayList<Comment>())
+                .avgScore(0)
+                .commentCount(0)
+                .build();
+
+        when(boardService.findById(boardId)).thenReturn(mockBoard);
+        BoardResponse.FindById response = boardFacadeImpl.findById(boardId, memberId);
+        assertNotNull(response);
+    }
+}


### PR DESCRIPTION
동시성 문제 테스트를 작성하던 중에 테스트가 어렵게 설계가 되어있었습니다

댓글, 게시글에서 update나 delete시 해당 사용자가 작성자인지 확인하는 부분이 service에 있어서 이를 facade에서 처리하도록 수정했습니다.

-> 단일 책임 원칙, 개방 폐쇄 원칙 