### PR TITLE
YJ1-55  token 예외 처리 및 오류 해결

### DIFF
--- a/src/main/java/com/yeojeong/application/security/config/refreshtoken/application/RefreshTokenService.java
+++ b/src/main/java/com/yeojeong/application/security/config/refreshtoken/application/RefreshTokenService.java
@@ -2,11 +2,14 @@ package com.yeojeong.application.security.config.refreshtoken.application;
 
 import com.yeojeong.application.domain.member.presentation.dto.MemberDetails;
 import com.yeojeong.application.security.config.refreshtoken.domain.RefreshToken;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 public interface RefreshTokenService {
     void save(RefreshToken data);
     RefreshToken findById(String token);
     void delete(RefreshToken token);
-    RefreshToken validRefresh(String token);
+    RefreshToken validRefresh(Cookie[] cookies, String token);
     String createRefresh(Long memberId, MemberDetails member);
 }

--- a/src/main/java/com/yeojeong/application/security/config/refreshtoken/presentation/RefreshController.java
+++ b/src/main/java/com/yeojeong/application/security/config/refreshtoken/presentation/RefreshController.java
@@ -2,6 +2,7 @@ package com.yeojeong.application.security.config.refreshtoken.presentation;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.yeojeong.application.config.exception.AuthedException;
 import com.yeojeong.application.config.util.customannotation.MethodTimer;
 import com.yeojeong.application.domain.member.presentation.dto.MemberDetails;
 import com.yeojeong.application.security.config.JwtProvider;
@@ -40,12 +41,13 @@ public class RefreshController {
             }
     )
     public ResponseEntity<Void> refresh(
-            @CookieValue(value = "Refresh") Cookie cookie, HttpServletRequest request, HttpServletResponse response, Authentication authResult
+            HttpServletRequest request, HttpServletResponse response, Authentication authResult
     ){
-        String refreshTokenHeader = cookie.getValue();
+        String refreshTokenHeader = null;
+        Cookie[] cookies = request.getCookies();
 
         // refresh token 이 유효한지 확인 -> 제거
-        RefreshToken savedRefreshToken = refreshTokenService.validRefresh(refreshTokenHeader);
+        RefreshToken savedRefreshToken = refreshTokenService.validRefresh(cookies, refreshTokenHeader);
         refreshTokenService.delete(savedRefreshToken);
 
         MemberDetails member = (MemberDetails) authResult.getPrincipal();
@@ -55,6 +57,7 @@ public class RefreshController {
 
         Cookie refreshCookie = new Cookie(jwtProvider.REFRESH_HEADER_STRING, jwtProvider.TOKEN_PREFIX_REFRESH + refreshToken);
         refreshCookie.setHttpOnly(true);
+        refreshCookie.setPath("/");
         refreshCookie.setMaxAge(jwtProvider.REFRESH_EXPIRATION_TIME / 1000);
 
         String jwtToken = jwtProvider.createJwtToken(member);
@@ -79,7 +82,7 @@ public class RefreshController {
             HttpServletRequest request, HttpServletResponse response
     ){
         String accessToken = request.getHeader(jwtProvider.JWT_HEADER_STRING);
-        if (accessToken == null) return null;//throw new RestApiException(ErrorCode.UNAUTHORIZED_CLIENT);
+        if (accessToken == null) throw new AuthedException("Access Token 이 존재하지 않습니다.");
 
         String token = accessToken.replace(jwtProvider.TOKEN_PREFIX_JWT, "");
 
@@ -87,10 +90,9 @@ public class RefreshController {
         try {
             userCode = JWT.require(Algorithm.HMAC512(jwtProvider.SECRET)).build().verify(token).getClaim("id").asLong();
         } catch (Exception e) {
-
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(false);
+            throw new AuthedException("Access Token 이 유효하지 않습니다.");
         }
 
-        return ResponseEntity.status(HttpStatus.OK).body(true);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 }


### PR DESCRIPTION
-token 전체적인 코드 예외처리 -> 쉽게 처리하기 위해 throw 로 예외처리
-refresh token 을 새롭게 발급받는 코드에서 RefreshController 가 "/token" 경로가 생기면서 2개의 Refresh 쿠키가 생기는 것을 확인 -> cookie.setPath("/") 로 오류 해결 
-@Cookie 어노테이션을 사용하여 쿠키를 가져왔지만 쿠키가 없을 시 500 에러를 보내는 것을 확인 -> 에러 통일화를 위해 Cookie 처리를 직접 해결