### PR TITLE
쿠키 수정

### DIFF
--- a/src/main/java/com/yeojeong/application/security/config/SecurityUtil.java
+++ b/src/main/java/com/yeojeong/application/security/config/SecurityUtil.java
@@ -1,5 +1,6 @@
 package com.yeojeong.application.security.config;
 
+import com.yeojeong.application.config.exception.AuthedException;
 import com.yeojeong.application.domain.member.presentation.dto.MemberDetails;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -14,5 +15,13 @@ public class SecurityUtil {
             return ((MemberDetails) authentication.getPrincipal()).getMemberId();
         }
         return null;
+    }
+
+    public static MemberDetails getCurrentMember(Authentication authResult) {
+        try {
+            return (MemberDetails) authResult.getPrincipal();
+        } catch (Exception e){
+            throw new AuthedException("access token 이 존재하지 않습니다.");
+        }
     }
 }

--- a/src/main/java/com/yeojeong/application/security/config/refreshtoken/application/RefreshTokenService.java
+++ b/src/main/java/com/yeojeong/application/security/config/refreshtoken/application/RefreshTokenService.java
@@ -12,4 +12,5 @@ public interface RefreshTokenService {
     void delete(RefreshToken token);
     RefreshToken validRefresh(Cookie[] cookies, String token);
     String createRefresh(Long memberId, MemberDetails member);
+    Cookie setRefreshCookie(String refreshToken);
 }

--- a/src/main/java/com/yeojeong/application/security/config/refreshtoken/application/implement/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/yeojeong/application/security/config/refreshtoken/application/implement/RefreshTokenServiceImpl.java
@@ -79,4 +79,14 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
 
         return refreshToken;
     }
+
+    @Override
+    public Cookie setRefreshCookie (String refreshToken) {
+        Cookie refreshCookie = new Cookie(jwtProvider.REFRESH_HEADER_STRING, jwtProvider.TOKEN_PREFIX_REFRESH + refreshToken);
+        refreshCookie.setAttribute("SameSite", "None");
+        refreshCookie.setHttpOnly(true);
+        refreshCookie.setPath("/");
+
+        return refreshCookie;
+    }
 }

--- a/src/main/java/com/yeojeong/application/security/config/refreshtoken/presentation/RefreshController.java
+++ b/src/main/java/com/yeojeong/application/security/config/refreshtoken/presentation/RefreshController.java
@@ -6,6 +6,7 @@ import com.yeojeong.application.config.exception.AuthedException;
 import com.yeojeong.application.config.util.customannotation.MethodTimer;
 import com.yeojeong.application.domain.member.presentation.dto.MemberDetails;
 import com.yeojeong.application.security.config.JwtProvider;
+import com.yeojeong.application.security.config.SecurityUtil;
 import com.yeojeong.application.security.config.refreshtoken.application.RefreshTokenService;
 import com.yeojeong.application.security.config.refreshtoken.domain.RefreshToken;
 import io.swagger.v3.oas.annotations.Operation;
@@ -50,15 +51,12 @@ public class RefreshController {
         RefreshToken savedRefreshToken = refreshTokenService.validRefresh(cookies, refreshTokenHeader);
         refreshTokenService.delete(savedRefreshToken);
 
-        MemberDetails member = (MemberDetails) authResult.getPrincipal();
+        MemberDetails member = SecurityUtil.getCurrentMember(authResult);
 
         // refresh token 을 새롭게 생성
         String refreshToken = refreshTokenService.createRefresh(member.getMemberId(), member);
 
-        Cookie refreshCookie = new Cookie(jwtProvider.REFRESH_HEADER_STRING, jwtProvider.TOKEN_PREFIX_REFRESH + refreshToken);
-        refreshCookie.setHttpOnly(true);
-        refreshCookie.setPath("/");
-        refreshCookie.setMaxAge(jwtProvider.REFRESH_EXPIRATION_TIME / 1000);
+        Cookie refreshCookie = refreshTokenService.setRefreshCookie(refreshToken);
 
         String jwtToken = jwtProvider.createJwtToken(member);
 

--- a/src/main/java/com/yeojeong/application/security/filter/LoginFilter.java
+++ b/src/main/java/com/yeojeong/application/security/filter/LoginFilter.java
@@ -75,9 +75,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         refreshTokenService.save(saveToken);
 
         // Refresh Token - Cookie
-        Cookie refreshCookie = new Cookie(jwtProvider.REFRESH_HEADER_STRING, jwtProvider.TOKEN_PREFIX_REFRESH + refreshToken);
-        refreshCookie.setHttpOnly(true);
-        refreshCookie.setMaxAge(jwtProvider.REFRESH_EXPIRATION_TIME / 1000);
+        Cookie refreshCookie = refreshTokenService.setRefreshCookie(refreshToken);
 
         // JWT token
         response.addHeader(jwtProvider.JWT_HEADER_STRING, jwtProvider.TOKEN_PREFIX_JWT + jwtToken);


### PR DESCRIPTION
ResponseCookie 를 사용하지 않고 기존에 Cookie 를 사용하는 로직으로 수정 

코드의 간략화를 위해 Cookie 를 설정하는 부분은 RefreshTokenServiceImpl 로 변경 

로그인한 멤버 정보를 불러오는 부분을 SecurityUtil 에 있는 getCurrentMemberId 를 사용하려 했으나 그대로의 멤버 정보도 필요해 getCurrentMember 메소드를 새로 생성 -> 이에 따라 access Token 이 없더라도 500 에러가 아닌 403 에러가 발생