### PR TITLE
YJ1-89 Planner, Location 수정

### DIFF
--- a/src/main/java/com/yeojeong/application/domain/member/presentation/dto/MemberResponse.java
+++ b/src/main/java/com/yeojeong/application/domain/member/presentation/dto/MemberResponse.java
@@ -3,14 +3,11 @@ package com.yeojeong.application.domain.member.presentation.dto;
 import com.yeojeong.application.domain.board.board.domain.Board;
 import com.yeojeong.application.domain.board.comment.domain.Comment;
 import com.yeojeong.application.domain.member.domain.Member;
-import com.yeojeong.application.domain.planner.location.presentation.dto.LocationResponse;
 import com.yeojeong.application.domain.planner.planner.domain.Planner;
-import com.yeojeong.application.domain.planner.planner.presentation.dto.PlannerResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 public class MemberResponse {
     @Builder
@@ -104,18 +101,8 @@ public class MemberResponse {
     public record PlannerInfo(
             Long id,
             String title,
-
-            Integer startYear,
-            Integer startMonth,
-            Integer startDay,
-            Integer startHour,
-            Integer startMinute,
-
-            Integer endYear,
-            Integer endMonth,
-            Integer endDay,
-            Integer endHour,
-            Integer endMinute,
+            String subTitle,
+            int personnel,
 
             int locationCount
     ) {
@@ -123,19 +110,8 @@ public class MemberResponse {
             return PlannerInfo.builder()
                     .id(planner.getId())
                     .title(planner.getTitle())
-
-                    .startYear(planner.getStartYear())
-                    .startMonth(planner.getStartMonth())
-                    .startDay(planner.getStartDay())
-                    .startHour(planner.getStartHour())
-                    .startMinute(planner.getStartMinute())
-
-                    .endYear(planner.getEndYear())
-                    .endMonth(planner.getEndMonth())
-                    .endDay(planner.getEndDay())
-                    .endHour(planner.getEndHour())
-                    .endMinute(planner.getEndMinute())
-
+                    .subTitle(planner.getSubTitle())
+                    .personnel(planner.getPersonnel())
                     .locationCount(planner.getLocationCount())
                     .build();
         }

--- a/src/main/java/com/yeojeong/application/domain/planner/location/application/locationfacade/implement/LocationFacadeImpl.java
+++ b/src/main/java/com/yeojeong/application/domain/planner/location/application/locationfacade/implement/LocationFacadeImpl.java
@@ -29,13 +29,6 @@ public class LocationFacadeImpl implements LocationFacade {
 
         Location entity = LocationRequest.Save.toEntity(dto, planner);
 
-        if (startDateValidation(planner, entity)){
-            throw new RequestDataException("Planner (시작 날짜) 에 해당하지 않는 날짜입니다.");
-        }
-        if (endDateValidation(planner, entity)) {
-            throw new RequestDataException("Planner (끝 날짜) 에 해당하지 않는 날짜입니다.");
-        }
-
         Location savedEntity = locationService.save(entity);
 
         if (planner.getLocationCount() >= 15) {
@@ -65,19 +58,10 @@ public class LocationFacadeImpl implements LocationFacade {
     @Transactional
     public LocationResponse.FindById update(LocationRequest.Put dto, Long id) {
         Location savedEntity = locationService.findById(id);
-        Location entity = LocationRequest.Put.toEntity(dto);
 
-        Planner planner = savedEntity.getPlanner();
+        savedEntity.update(dto);
 
-        if (startDateValidation(planner, entity)){
-            throw new RequestDataException("Planner (시작 날짜) 에 해당하지 않는 날짜입니다.");
-        }
-        if (endDateValidation(planner, entity)) {
-            throw new RequestDataException("Planner (끝 날짜) 에 해당하지 않는 날짜입니다.");
-        }
-
-        savedEntity.update(entity);
-        Location rtnEntity = locationService.update(entity);
+        Location rtnEntity = locationService.update(savedEntity);
         return LocationResponse.FindById.toDto(rtnEntity);
     }
 
@@ -93,33 +77,5 @@ public class LocationFacadeImpl implements LocationFacade {
         return locationList.stream()
                 .map(LocationResponse.FindById::toDto)
                 .collect(Collectors.toList());
-    }
-
-    public boolean startDateValidation (Planner planner, Location location) {
-        if (location.getYear() < planner.getStartYear()){
-            return true;
-        } else if (location.getYear() == planner.getStartYear() && location.getMonth() < planner.getStartMonth()) {
-            return true;
-        } else if (location.getYear() == planner.getStartYear() && location.getMonth() == planner.getStartMonth() && location.getDay() < planner.getStartDay()) {
-            return true;
-        } else if (location.getYear() == planner.getStartYear() && location.getMonth() == planner.getStartMonth() && location.getDay() == planner.getStartDay() && location.getHour() < planner.getStartHour()) {
-            return true;
-        } else if (location.getYear() == planner.getStartYear() && location.getMonth() == planner.getStartMonth() && location.getDay() == planner.getStartDay() && location.getHour() == planner.getStartHour() && location.getMinute() < planner.getStartMinute()) {
-            return true;
-        } return false;
-    }
-
-    public boolean endDateValidation (Planner planner, Location location) {
-        if (location.getYear() > planner.getEndYear()){
-            return true;
-        } else if (location.getYear() == planner.getEndYear() && location.getMonth() > planner.getEndMonth()) {
-            return true;
-        } else if (location.getYear() == planner.getEndYear() && location.getMonth() == planner.getEndMonth() && location.getDay() > planner.getEndDay()) {
-            return true;
-        } else if (location.getYear() == planner.getEndYear() && location.getMonth() == planner.getEndMonth() && location.getDay() == planner.getEndDay() && location.getHour() > planner.getEndHour()) {
-            return true;
-        } else if (location.getYear() == planner.getEndYear() && location.getMonth() == planner.getEndMonth() && location.getDay() == planner.getEndDay() && location.getHour() == planner.getEndHour() && location.getMinute() > planner.getEndMinute()) {
-            return true;
-        } return false;
     }
 }

--- a/src/main/java/com/yeojeong/application/domain/planner/location/application/locationservice/LocationService.java
+++ b/src/main/java/com/yeojeong/application/domain/planner/location/application/locationservice/LocationService.java
@@ -9,8 +9,6 @@ public interface LocationService {
     Location findById(Long id);
     Location update(Location entity);
     void delete(Location entity);
-    boolean existBefore(Integer year, Integer month, Integer day, Integer hour, Integer minute);
-    boolean existAfter(Integer year, Integer month, Integer day, Integer hour, Integer minute);
     List<Location> findByPlannerId(Long plannerId);
     void deleteByPlannerId(Long plannerId);
 }

--- a/src/main/java/com/yeojeong/application/domain/planner/location/application/locationservice/implement/LocationServiceImpl.java
+++ b/src/main/java/com/yeojeong/application/domain/planner/location/application/locationservice/implement/LocationServiceImpl.java
@@ -42,17 +42,7 @@ public class LocationServiceImpl implements LocationService {
     }
 
     @Override
-    public boolean existBefore(Integer year, Integer month, Integer day, Integer hour, Integer minute) {
-        return locationRepository.existsBefore(year, month, day, hour, minute);
-    }
-
-    @Override
-    public boolean existAfter(Integer year, Integer month, Integer day, Integer hour, Integer minute) {
-        return locationRepository.existsAfter(year, month, day, hour, minute);
-    }
-
-    @Override
     public List<Location> findByPlannerId(Long plannerId) {
-        return locationRepository.findAllByPlannerId(plannerId);
+        return locationRepository.findAllByPlannerIdOrderByUnixTime(plannerId);
     }
 }

--- a/src/main/java/com/yeojeong/application/domain/planner/location/domain/Location.java
+++ b/src/main/java/com/yeojeong/application/domain/planner/location/domain/Location.java
@@ -1,12 +1,16 @@
 package com.yeojeong.application.domain.planner.location.domain;
 
 import com.yeojeong.application.config.util.BaseTime;
+import com.yeojeong.application.domain.planner.location.presentation.dto.LocationRequest;
 import com.yeojeong.application.domain.planner.planner.domain.Planner;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 @Entity
 @Builder
@@ -18,25 +22,17 @@ public class Location extends BaseTime {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
+    private Long unixTime;
+
     @Column
     private int travelTime;
 
+    @Column
+    private String transportation;
 
-    @Column(nullable = false)
-    private int year;
-
-    @Column(nullable = false)
-    private int month;
-
-    @Column(nullable = false)
-    private int day;
-
-    @Column(nullable = false)
-    private int hour;
-
-    @Column(nullable = false)
-    private int minute;
-
+    @Column
+    private String transportationNote;
 
     @Column(nullable = false)
     private String place;
@@ -45,23 +41,28 @@ public class Location extends BaseTime {
     private String address;
 
     @Column
+    private String phoneNumber;
+
+    @Column
     private String memo;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "planner_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Planner planner;
 
-    public void update(Location entity) {
-        this.travelTime = entity.getTravelTime();
-        this.year = entity.getYear();
-        this.month = entity.getMonth();
-        this.day = entity.getDay();
+    public void update(LocationRequest.Put dto) {
+        LocalDateTime localDateTime = LocalDateTime.of(dto.year(), dto.month(), dto.day(), dto.hour(), dto.minute());
+        this.unixTime = Timestamp.valueOf(localDateTime).getTime();
 
-        this.hour = entity.getHour();
-        this.minute = entity.getMinute();
+        this.travelTime = dto.travelTime();
+        this.transportation = dto.transportation();
+        this.transportationNote = dto.transportationNote();
 
-        this.place = entity.getPlace();
-        this.address = entity.getAddress();
-        this.memo = entity.getMemo();
+        this.place = dto.place();
+        this.address = dto.address();
+        this.phoneNumber = dto.phoneNumber();
+        this.memo = dto.memo();
     }
+
+
 }

--- a/src/main/java/com/yeojeong/application/domain/planner/location/domain/LocationRepository.java
+++ b/src/main/java/com/yeojeong/application/domain/planner/location/domain/LocationRepository.java
@@ -7,31 +7,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface LocationRepository extends JpaRepository<Location, Long> {
-    List<Location> findAllByPlannerId(Long plannerId);
-
-    @Query("SELECT COUNT(e) > 0 FROM Location e " +
-            "WHERE (e.year < :year) OR " +
-            "(e.year = :year AND e.month < :month) OR " +
-            "(e.year = :year AND e.month = :month AND e.day < :day) OR " +
-            "(e.year = :year AND e.month = :month AND e.day = :day AND e.hour < :hour) OR " +
-            "(e.year = :year AND e.month = :month AND e.day = :day AND e.hour = :hour AND e.minute < :minute)")
-    boolean existsBefore(@Param("year") int year,
-                         @Param("month") int month,
-                         @Param("day") int day,
-                         @Param("hour") int hour,
-                         @Param("minute") int minute);
-
-    @Query("SELECT COUNT(e) > 0 FROM Location e " +
-            "WHERE (e.year > :year) OR " +
-            "(e.year = :year AND e.month > :month) OR " +
-            "(e.year = :year AND e.month = :month AND e.day > :day) OR " +
-            "(e.year = :year AND e.month = :month AND e.day = :day AND e.hour > :hour) OR " +
-            "(e.year = :year AND e.month = :month AND e.day = :day AND e.hour = :hour AND e.minute > :minute)")
-    boolean existsAfter(@Param("year") int year,
-                        @Param("month") int month,
-                        @Param("day") int day,
-                        @Param("hour") int hour,
-                        @Param("minute") int minute);
+    List<Location> findAllByPlannerIdOrderByUnixTime(Long plannerId);
 
     void deleteByPlannerId(Long plannerId);
 }

--- a/src/main/java/com/yeojeong/application/domain/planner/location/presentation/dto/LocationRequest.java
+++ b/src/main/java/com/yeojeong/application/domain/planner/location/presentation/dto/LocationRequest.java
@@ -3,60 +3,55 @@ package com.yeojeong.application.domain.planner.location.presentation.dto;
 import com.yeojeong.application.domain.planner.location.domain.Location;
 import com.yeojeong.application.domain.planner.planner.domain.Planner;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+
 public class LocationRequest {
     @Builder
     @Schema(name = "장소 작성")
     public record Save(
+            @NotNull
+            Integer year,
+            @NotNull
+            Integer month,
+            @NotNull
+            Integer day,
+            @NotNull
+            Integer hour,
+            @NotNull
+            Integer minute,
             @Min(0)
             Integer travelTime,
 
-            @NotNull
-            @Min(2024)
-            Integer year,
-
-            @NotNull
-            @Min(1) @Max(12)
-            Integer month,
-
-            @NotNull
-            @Min(1) @Max(31)
-            Integer day,
-
-            @NotNull
-            @Min(1) @Max(24)
-            Integer hour,
-
-            @NotNull
-            @Min(1) @Max(60)
-            Integer minute,
+            String transportation,
+            String transportationNote,
 
             @NotBlank
             String place,
-
             @NotBlank
             String address,
+            String phoneNumber,
 
             String memo
     ){
         public static Location toEntity (Save dto, Planner planner) {
+            Long unixTime = returnUnixTime(dto.year(), dto.month(), dto.day(), dto.hour(), dto.minute());
+
             return Location.builder()
+                    .unixTime(unixTime)
                     .travelTime(dto.travelTime())
 
-                    .year(dto.year())
-                    .month(dto.month())
-                    .day(dto.day())
-
-                    .hour(dto.hour())
-                    .minute(dto.minute())
+                    .transportation(dto.transportation())
+                    .transportationNote(dto.transportationNote())
 
                     .place(dto.place())
                     .address(dto.address())
+                    .phoneNumber(dto.phoneNumber())
                     .memo(dto.memo())
 
                     .planner(planner)
@@ -67,53 +62,36 @@ public class LocationRequest {
     @Builder
     @Schema(name = "장소 수정")
     public record Put(
+            @NotNull
+            Integer year,
+            @NotNull
+            Integer month,
+            @NotNull
+            Integer day,
+            @NotNull
+            Integer hour,
+            @NotNull
+            Integer minute,
             @Min(0)
             Integer travelTime,
 
-            @NotNull
-            @Min(2024)
-            Integer year,
-
-            @NotNull
-            @Min(1) @Max(12)
-            Integer month,
-
-            @NotNull
-            @Min(1) @Max(31)
-            Integer day,
-
-            @NotNull
-            @Min(1) @Max(24)
-            Integer hour,
-
-            @NotNull
-            @Min(1) @Max(60)
-            Integer minute,
+            String transportation,
+            String transportationNote,
 
             @NotBlank
             String place,
-
             @NotBlank
             String address,
+            String phoneNumber,
 
             String memo
     ){
-        public static Location toEntity (Put dto) {
-            return Location.builder()
-                    .travelTime(dto.travelTime())
 
-                    .year(dto.year())
-                    .month(dto.month())
-                    .day(dto.day())
+    }
 
-                    .hour(dto.hour())
-                    .minute(dto.minute())
-
-                    .place(dto.place())
-                    .address(dto.address())
-                    .memo(dto.memo())
-                    .build();
-        }
+    private static Long returnUnixTime(Integer year, Integer month, Integer day, Integer hour, Integer minute) {
+        LocalDateTime localDateTime = LocalDateTime.of(year, month, day, hour, minute);
+        return Timestamp.valueOf(localDateTime).getTime();
     }
 
 }

--- a/src/main/java/com/yeojeong/application/domain/planner/location/presentation/dto/LocationResponse.java
+++ b/src/main/java/com/yeojeong/application/domain/planner/location/presentation/dto/LocationResponse.java
@@ -4,6 +4,10 @@ import com.yeojeong.application.domain.planner.location.domain.Location;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.TimeZone;
+
 public class LocationResponse {
     @Builder
     @Schema(name = "장소 조회")
@@ -23,17 +27,18 @@ public class LocationResponse {
             String memo
     ) {
         public static FindById toDto(Location entity) {
+            LocalDateTime localDateTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(entity.getUnixTime()), TimeZone.getDefault().toZoneId());
             return FindById.builder()
                     .id(entity.getId())
 
                     .travelTime(entity.getTravelTime())
 
-                    .year(entity.getYear())
-                    .month(entity.getMonth())
-                    .day(entity.getDay())
+                    .year(localDateTime.getYear())
+                    .month(localDateTime.getMonthValue())
+                    .day(localDateTime.getDayOfMonth())
 
-                    .hour(entity.getHour())
-                    .minute(entity.getMinute())
+                    .hour(localDateTime.getHour())
+                    .minute(localDateTime.getMinute())
 
                     .place(entity.getPlace())
                     .address(entity.getAddress())

--- a/src/main/java/com/yeojeong/application/domain/planner/planner/application/plannerfacade/implement/PlannerFacadeImpl.java
+++ b/src/main/java/com/yeojeong/application/domain/planner/planner/application/plannerfacade/implement/PlannerFacadeImpl.java
@@ -1,7 +1,6 @@
 package com.yeojeong.application.domain.planner.planner.application.plannerfacade.implement;
 
 import com.yeojeong.application.config.exception.OwnershipException;
-import com.yeojeong.application.config.exception.RequestDataException;
 import com.yeojeong.application.domain.member.application.memberservice.MemberService;
 import com.yeojeong.application.domain.member.domain.Member;
 import com.yeojeong.application.domain.planner.location.application.locationservice.LocationService;
@@ -44,15 +43,7 @@ public class PlannerFacadeImpl implements PlannerFacade {
         Planner savedEntity = plannerService.findById(id);
         checkMember(savedEntity, memberId);
 
-        if (locationService.existBefore(dto.startYear(), dto.startMonth(), dto.startDay(), dto.startHour(), dto.startMinute())){
-            throw new RequestDataException("시작 날짜 변경 : Planner 와 관련된 Location 정보가 존재합니다.");
-        }
-        if (locationService.existAfter(dto.endYear(), dto.endMonth(), dto.endDay(), dto.endHour(), dto.endMinute())){
-            throw new RequestDataException("끝나는 날짜 변경 : Planner 와 관련된 Location 정보가 존재합니다.");
-        }
-
-        Planner entity = PlannerRequest.Put.toEntity(dto);
-        savedEntity.update(entity);
+        savedEntity.update(dto);
 
         Planner rtnEntity = plannerService.update(savedEntity);
 

--- a/src/main/java/com/yeojeong/application/domain/planner/planner/domain/Planner.java
+++ b/src/main/java/com/yeojeong/application/domain/planner/planner/domain/Planner.java
@@ -3,6 +3,7 @@ package com.yeojeong.application.domain.planner.planner.domain;
 import com.yeojeong.application.config.util.BaseTime;
 import com.yeojeong.application.domain.member.domain.Member;
 import com.yeojeong.application.domain.planner.location.domain.Location;
+import com.yeojeong.application.domain.planner.planner.presentation.dto.PlannerRequest;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -25,34 +26,10 @@ public class Planner extends BaseTime {
     private String title;
 
     @Column(nullable = false)
-    private int startYear;
+    private int personnel;
 
-    @Column(nullable = false)
-    private int startMonth;
-
-    @Column(nullable = false)
-    private int startDay;
-
-    @Column(nullable = false)
-    private int startHour;
-
-    @Column(nullable = false)
-    private int startMinute;
-
-    @Column(nullable = false)
-    private int endYear;
-
-    @Column(nullable = false)
-    private int endMonth;
-
-    @Column(nullable = false)
-    private int endDay;
-
-    @Column(nullable = false)
-    private int endHour;
-
-    @Column(nullable = false)
-    private int endMinute;
+    @Column
+    private String subTitle;
 
     @Column(nullable = false)
     private int locationCount;
@@ -64,20 +41,10 @@ public class Planner extends BaseTime {
     @JoinColumn(name = "member_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Member member;
 
-    public void update(Planner entity) {
-        title = entity.getTitle();
-
-        startYear = entity.getStartYear();
-        startMonth = entity.getStartMonth();
-        startDay = entity.getStartDay();
-        startHour = entity.getStartHour();
-        startMinute = entity.getStartMinute();
-
-        endYear = entity.getEndYear();
-        endMonth = entity.getEndMonth();
-        endDay = entity.getEndDay();
-        endHour = entity.getEndHour();
-        endMinute = entity.getEndMinute();
+    public void update(PlannerRequest.Put dto) {
+        title = dto.title();
+        personnel = dto.personnel();
+        subTitle = dto.subTitle();
     }
 
     public void addLocation(){

--- a/src/main/java/com/yeojeong/application/domain/planner/planner/presentation/dto/PlannerRequest.java
+++ b/src/main/java/com/yeojeong/application/domain/planner/planner/presentation/dto/PlannerRequest.java
@@ -5,53 +5,22 @@ import com.yeojeong.application.domain.planner.planner.domain.Planner;
 import jakarta.validation.constraints.*;
 import lombok.Builder;
 
-import java.util.List;
-
 public class PlannerRequest {
     @Builder
     public record Save(
             @NotNull @Size(min = 1, max = 30)
             String title,
-
-            @Min(2024)
-            Integer startYear,
-            @Min(1) @Max(12)
-            Integer startMonth,
-            @Min(1) @Max(31)
-            Integer startDay,
-            @Min(0) @Max(23)
-            Integer startHour,
-            @Min(0) @Max(59)
-            Integer startMinute,
-
-            @Min(2024)
-            Integer endYear,
-            @Min(1) @Max(12)
-            Integer endMonth,
-            @Min(1) @Max(31)
-            Integer endDay,
-            @Min(0) @Max(23)
-            Integer endHour,
-            @Min(0) @Max(59)
-            Integer endMinute
+            @NotNull
+            int personnel,
+            @Size(max = 30)
+            String subTitle
 
     ) {
         public static Planner toEntity(PlannerRequest.Save dto, Member member) {
             return Planner.builder()
                     .title(dto.title())
-
-                    .startYear(dto.startYear())
-                    .startMonth(dto.startMonth())
-                    .startDay(dto.startDay())
-                    .startHour(dto.startHour())
-                    .startMinute(dto.startMinute())
-
-                    .endYear(dto.endYear())
-                    .endMonth(dto.endMonth())
-                    .endDay(dto.endDay())
-                    .endHour(dto.endHour())
-                    .endMinute(dto.endMinute())
-
+                    .personnel(dto.personnel())
+                    .subTitle(dto.subTitle())
                     .member(member)
                     .build();
         }
@@ -60,44 +29,16 @@ public class PlannerRequest {
     public record Put(
             @NotNull @Size(min = 1, max = 30)
             String title,
-
-            @Min(2024)
-            Integer startYear,
-            @Min(1) @Max(12)
-            Integer startMonth,
-            @Min(1) @Max(31)
-            Integer startDay,
-            @Min(0) @Max(23)
-            Integer startHour,
-            @Min(0) @Max(59)
-            Integer startMinute,
-
-            @Min(2024)
-            Integer endYear,
-            @Min(1) @Max(12)
-            Integer endMonth,
-            @Min(1) @Max(31)
-            Integer endDay,
-            @Min(0) @Max(23)
-            Integer endHour,
-            @Min(0) @Max(59)
-            Integer endMinute
+            @NotNull
+            int personnel,
+            @Size(max = 30)
+            String subTitle
     ) {
         public static Planner toEntity(PlannerRequest.Put dto) {
             return Planner.builder()
                     .title(dto.title())
-
-                    .startYear(dto.startYear())
-                    .startMonth(dto.startMonth())
-                    .startDay(dto.startDay())
-                    .startHour(dto.startHour())
-                    .startMinute(dto.startMinute())
-
-                    .endYear(dto.endYear())
-                    .endMonth(dto.endMonth())
-                    .endDay(dto.endDay())
-                    .endHour(dto.endHour())
-                    .endMinute(dto.endMinute())
+                    .personnel(dto.personnel())
+                    .subTitle(dto.subTitle())
                     .build();
         }
     }

--- a/src/main/java/com/yeojeong/application/domain/planner/planner/presentation/dto/PlannerResponse.java
+++ b/src/main/java/com/yeojeong/application/domain/planner/planner/presentation/dto/PlannerResponse.java
@@ -1,6 +1,5 @@
 package com.yeojeong.application.domain.planner.planner.presentation.dto;
 
-import com.yeojeong.application.domain.planner.location.domain.Location;
 import com.yeojeong.application.domain.planner.location.presentation.dto.LocationResponse;
 import com.yeojeong.application.domain.planner.planner.domain.Planner;
 import lombok.Builder;
@@ -13,18 +12,8 @@ public class PlannerResponse {
     public record FindById(
             Long id,
             String title,
-
-            Integer startYear,
-            Integer startMonth,
-            Integer startDay,
-            Integer startHour,
-            Integer startMinute,
-
-            Integer endYear,
-            Integer endMonth,
-            Integer endDay,
-            Integer endHour,
-            Integer endMinute,
+            int personnel,
+            String subTitle,
 
             int locationCount,
             List<LocationResponse.FindById> locationInfo
@@ -33,18 +22,8 @@ public class PlannerResponse {
             return FindById.builder()
                     .id(planner.getId())
                     .title(planner.getTitle())
-
-                    .startYear(planner.getStartYear())
-                    .startMonth(planner.getStartMonth())
-                    .startDay(planner.getStartDay())
-                    .startHour(planner.getStartHour())
-                    .startMinute(planner.getStartMinute())
-
-                    .endYear(planner.getEndYear())
-                    .endMonth(planner.getEndMonth())
-                    .endDay(planner.getEndDay())
-                    .endHour(planner.getEndHour())
-                    .endMinute(planner.getEndMinute())
+                    .personnel(planner.getPersonnel())
+                    .subTitle(planner.getSubTitle())
 
                     .locationCount(planner.getLocationCount())
                     .locationInfo(locationInfo)


### PR DESCRIPTION
# 수정사항

- [x] Planner 날짜 항목 삭제
- [x] Planner 인원수, 부제 칼럼 생성
- [x] Location 날짜를 timestamp 로 변환 -> 정렬도 이 값으로 정렬
- [x] Location 수정을 할 때 dto 를 엔티티로 변환 후 수정 로직을 dto 그래도 수정하도록 함 -> 계속 builder 가 사용되면서 필요 이상의 Id 값이 높아짐


# 논의 사항
- Location 제한 개수를 계속 15개로 할 것인지 변경할 것인지 정해야 함
- Location 을 같은 시간을 제한할 것인지 정해야 함