### PR TITLE
이미지 저장 및 조회 로직

### DIFF
--- a/src/main/java/com/yeojeong/application/config/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/yeojeong/application/config/exception/handler/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.yeojeong.application.config.exception.response.ExceptionResponseSende
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.tomcat.util.http.fileupload.impl.InvalidContentTypeException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.FieldError;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
 import java.text.MessageFormat;
@@ -66,7 +68,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(RequestDataException.class)
     public void handlerRequestDataException(RequestDataException ex, HttpServletRequest request, HttpServletResponse response) {
-        int httpStatus = HttpStatus.NOT_FOUND.value();
+        int httpStatus = HttpStatus.BAD_REQUEST.value();
         String message = ex.getMessage();
         ExceptionResponseSender.createExceptionResponse(httpStatus, request, response, message);
     }
@@ -89,6 +91,20 @@ public class GlobalExceptionHandler {
     public void handlerAuthException(AuthedException ex, HttpServletRequest request, HttpServletResponse response) {
         int httpStatus = HttpStatus.FORBIDDEN.value();
         String message = ex.getMessage();
+        ExceptionResponseSender.createExceptionResponse(httpStatus, request, response, message);
+    }
+
+    @ExceptionHandler(InvalidContentTypeException.class)
+    public void handlerInvalidContentTypeException(InvalidContentTypeException ex, HttpServletRequest request, HttpServletResponse response) {
+        int httpStatus = HttpStatus.BAD_REQUEST.value();
+        String message = "데이터 형식이 잘못되었습니다.";
+        ExceptionResponseSender.createExceptionResponse(httpStatus, request, response, message);
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public void handlerMaxUploadSizeExceededException(MaxUploadSizeExceededException ex, HttpServletRequest request, HttpServletResponse response) {
+        int httpStatus = HttpStatus.PAYLOAD_TOO_LARGE.value();
+        String message = "파일 크기가 너무 큽니다.";
         ExceptionResponseSender.createExceptionResponse(httpStatus, request, response, message);
     }
 

--- a/src/main/java/com/yeojeong/application/config/webconfig/ImageResourceResolver.java
+++ b/src/main/java/com/yeojeong/application/config/webconfig/ImageResourceResolver.java
@@ -1,0 +1,38 @@
+package com.yeojeong.application.config.webconfig;
+
+import com.yeojeong.application.config.exception.NotFoundDataException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.web.servlet.resource.ResourceResolver;
+import org.springframework.web.servlet.resource.ResourceResolverChain;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+public class ImageResourceResolver implements ResourceResolver {
+
+    private final String PATH;
+
+    public ImageResourceResolver(String PATH) {
+        this.PATH = PATH;
+    }
+
+    @Override
+    public Resource resolveResource(HttpServletRequest request, String requestPath, List<? extends Resource> locations, ResourceResolverChain chain) {
+        File file = new File(PATH + requestPath);
+        if(!file.exists()) throw new NotFoundDataException("파일을 찾을 수 없습니다: " + requestPath);
+        try {
+            return new UrlResource(file.toURI());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public String resolveUrlPath(String resourcePath, List<? extends Resource> locations, ResourceResolverChain chain) {
+        return chain.resolveUrlPath(resourcePath, locations);
+    }
+}

--- a/src/main/java/com/yeojeong/application/config/webconfig/WebConfig.java
+++ b/src/main/java/com/yeojeong/application/config/webconfig/WebConfig.java
@@ -1,0 +1,23 @@
+package com.yeojeong.application.config.webconfig;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.servlet.resource.PathResourceResolver;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${filePath}")
+    private String PATH;
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        String viewPath = "/files/**";
+        registry.addResourceHandler(viewPath)
+                .addResourceLocations("file:///" + PATH)
+                .resourceChain(true)
+                .addResolver(new ImageResourceResolver(PATH));
+    }
+}

--- a/src/main/java/com/yeojeong/application/domain/board/board/application/boardfacade/ImageFacade.java
+++ b/src/main/java/com/yeojeong/application/domain/board/board/application/boardfacade/ImageFacade.java
@@ -1,0 +1,50 @@
+package com.yeojeong.application.domain.board.board.application.boardfacade;
+
+import com.yeojeong.application.config.exception.RequestDataException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+import java.util.logging.Logger;
+
+@Service
+public class ImageFacade {
+    private static final Logger logger = Logger.getLogger(ImageFacade.class.getName());
+    String[] checkExtensionArr = {"jpg", "jpeg", "png", "gif"};
+
+    @Value("${filePath}")
+    private String PATH;
+
+    public String saveImage(MultipartFile image) {
+        if (!checkExtension(image)) throw new RequestDataException("파일의 형식이 잘못되었습니다.");
+
+        String originFileName = StringUtils.getFilename(image.getOriginalFilename());
+        String serverFileName = UUID.randomUUID().toString() + "_" + originFileName;
+
+        String serverSavePath = PATH + serverFileName;
+        try {
+            File dest = new File(serverSavePath);
+            image.transferTo(dest);
+        } catch (IOException e) {
+            throw new RuntimeException("파일을 저장하지 못했습니다.");
+        }
+
+        return serverFileName;
+    }
+
+    private boolean checkExtension(MultipartFile file) {
+        String filename = file.getOriginalFilename();
+        if (filename == null || filename.isEmpty()) return false;
+        String extension = StringUtils.getFilenameExtension(filename);
+
+        for (String checkExtension : checkExtensionArr) {
+            if (extension != null && extension.equalsIgnoreCase(checkExtension)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/yeojeong/application/domain/board/board/presentation/AuthedBoardController.java
+++ b/src/main/java/com/yeojeong/application/domain/board/board/presentation/AuthedBoardController.java
@@ -1,6 +1,7 @@
 package com.yeojeong.application.domain.board.board.presentation;
 
 import com.yeojeong.application.domain.board.board.application.boardfacade.BoardFacade;
+import com.yeojeong.application.domain.board.board.application.boardfacade.ImageFacade;
 import com.yeojeong.application.domain.board.board.presentation.dto.BoardResponse;
 import com.yeojeong.application.domain.board.board.presentation.dto.BoardRequest;
 import com.yeojeong.application.config.util.customannotation.MethodTimer;
@@ -10,11 +11,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -24,6 +27,7 @@ import org.springframework.web.bind.annotation.*;
 public class AuthedBoardController {
 
     private final BoardFacade boardFacade;
+    private final ImageFacade imageFacade;
 
     @MethodTimer(method = "게시글 작성")
     @PostMapping
@@ -74,5 +78,10 @@ public class AuthedBoardController {
         Long memberId = SecurityUtil.getCurrentMemberId();
         boardFacade.delete(id, memberId);
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/images")
+    public ResponseEntity<String> images(@RequestPart(value = "image", required = false) @NonNull MultipartFile image) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(imageFacade.saveImage(image));
     }
 }

--- a/src/main/java/com/yeojeong/application/security/filter/SecurityFilter.java
+++ b/src/main/java/com/yeojeong/application/security/filter/SecurityFilter.java
@@ -44,7 +44,7 @@ public class SecurityFilter {
 
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/members/authed/**").authenticated()
-//                        .requestMatchers("/boards/authed/**").authenticated()
+                        .requestMatchers("/boards/authed/**").authenticated()
                         .requestMatchers("/boards/comments/authed/**").authenticated()
                         .anyRequest().permitAll());
 

--- a/src/main/java/com/yeojeong/application/security/filter/SecurityFilter.java
+++ b/src/main/java/com/yeojeong/application/security/filter/SecurityFilter.java
@@ -44,7 +44,7 @@ public class SecurityFilter {
 
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/members/authed/**").authenticated()
-                        .requestMatchers("/boards/authed/**").authenticated()
+//                        .requestMatchers("/boards/authed/**").authenticated()
                         .requestMatchers("/boards/comments/authed/**").authenticated()
                         .anyRequest().permitAll());
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,3 +4,9 @@ spring:
   web:
     resources:
       add-mappings: false
+  servlet:
+    multipart:
+      max-file-size: 2MB
+      max-request-size: 2MB
+
+filePath: ${filePath}


### PR DESCRIPTION
이미지 저장 및 조회 로직 마무리 했습니다.
해당 작업을 Merge하게 되면 CI/CD 수행 시 오류가 날 것 같은데 서버 설정 오류라 코드 리뷰 마무리 되는 대로 오류 수정 작업할게요!

### 작업 내용
1. 이미지 저장 엔드포인트 생성
2. 이미지 저장 Facade 생성
3. 정적 데이터 조회 엔드포인트 생성
> PATH: /files/{이미지 명}
4. 데이터의 크기는 2MB로 제한
>배경이 없는 이미지와 움직이는 이미지는 필요성을 못느껴
>JPG만 허용하며 JPG 형식이 아닐 경우 400을 반환합니다.
5. 이미지 저장은 로그인된 유저만 가능합니다


파일 저장은 UUID+파일 명으로 생성됩니다. 이는 파일의 명이 같을 경우 중복을 제거하기 위함입니다.

