### PR TITLE
게시글에 planner Id 조회 가능하게 수정

### DIFF
--- a/src/main/java/com/yeojeong/application/config/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/yeojeong/application/config/exception/handler/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.tomcat.util.http.fileupload.impl.InvalidContentTypeException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -18,6 +19,7 @@ import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
 import java.text.MessageFormat;
+import java.time.DateTimeException;
 import java.util.List;
 
 @Slf4j
@@ -105,6 +107,20 @@ public class GlobalExceptionHandler {
     public void handlerMaxUploadSizeExceededException(MaxUploadSizeExceededException ex, HttpServletRequest request, HttpServletResponse response) {
         int httpStatus = HttpStatus.PAYLOAD_TOO_LARGE.value();
         String message = "파일 크기가 너무 큽니다.";
+        ExceptionResponseSender.createExceptionResponse(httpStatus, request, response, message);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public void handlerHttpMessageNotReadableException(HttpMessageNotReadableException ex, HttpServletRequest request, HttpServletResponse response) {
+        int httpStatus = HttpStatus.BAD_REQUEST.value();
+        String message = ex.getMessage();
+        ExceptionResponseSender.createExceptionResponse(httpStatus, request, response, message);
+    }
+
+    @ExceptionHandler(DateTimeException.class)
+    public void handlerDateTimeException(DateTimeException ex, HttpServletRequest request, HttpServletResponse response) {
+        int httpStatus = HttpStatus.BAD_REQUEST.value();
+        String message = ex.getMessage();
         ExceptionResponseSender.createExceptionResponse(httpStatus, request, response, message);
     }
 

--- a/src/main/java/com/yeojeong/application/domain/board/board/application/boardfacade/implement/BoardFacadeImpl.java
+++ b/src/main/java/com/yeojeong/application/domain/board/board/application/boardfacade/implement/BoardFacadeImpl.java
@@ -9,6 +9,8 @@ import com.yeojeong.application.domain.board.board.presentation.dto.BoardRequest
 import com.yeojeong.application.domain.board.board.presentation.dto.BoardResponse;
 import com.yeojeong.application.domain.member.application.memberservice.MemberService;
 import com.yeojeong.application.domain.member.domain.Member;
+import com.yeojeong.application.domain.planner.planner.application.plannerservice.PlannerService;
+import com.yeojeong.application.domain.planner.planner.domain.Planner;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
@@ -20,13 +22,16 @@ public class BoardFacadeImpl implements BoardFacade {
 
     private final BoardService boardService;
     private final MemberService memberService;
+    private final PlannerService plannerService;
 
     @Override
     @Transactional
     public BoardResponse.FindById save(BoardRequest.Save dto, Long memberId) {
         Member member = memberService.findById(memberId);
+        if(!(dto.plannerId() == null)) plannerService.findById(dto.plannerId());
+
         Board entity = BoardRequest.Save.toEntity(dto, member);
-        Board savedEntity = boardService.save(entity, member);
+        Board savedEntity = boardService.save(entity);
 
         return BoardResponse.FindById.toDto(savedEntity);
     }
@@ -36,6 +41,7 @@ public class BoardFacadeImpl implements BoardFacade {
     public BoardResponse.FindById update(Long id, Long memberId, BoardRequest.Put dto) {
         Board savedEntity = boardService.findById(id);
         checkMember(savedEntity, memberId);
+        if(!(dto.plannerId() == null)) plannerService.findById(dto.plannerId());
 
         Board entity = BoardRequest.Put.toEntity(dto);
         savedEntity.update(entity);

--- a/src/main/java/com/yeojeong/application/domain/board/board/application/boardservice/BoardService.java
+++ b/src/main/java/com/yeojeong/application/domain/board/board/application/boardservice/BoardService.java
@@ -5,7 +5,7 @@ import com.yeojeong.application.domain.member.domain.Member;
 import org.springframework.data.domain.Page;
 
 public interface BoardService {
-    Board save(Board entity, Member member);
+    Board save(Board entity);
     Board update(Board entity);
     Board findById(Long id);
     Page<Board> findByMember(Long memberId, int page);

--- a/src/main/java/com/yeojeong/application/domain/board/board/application/boardservice/implement/BoardServiceImpl.java
+++ b/src/main/java/com/yeojeong/application/domain/board/board/application/boardservice/implement/BoardServiceImpl.java
@@ -27,7 +27,7 @@ public class BoardServiceImpl implements BoardService {
     private final AutocompleteService autocompleteService;
 
     @Override
-    public Board save(Board entity, Member member) {
+    public Board save(Board entity) {
         return boardRepository.save(entity);
     }
 

--- a/src/main/java/com/yeojeong/application/domain/board/board/domain/Board.java
+++ b/src/main/java/com/yeojeong/application/domain/board/board/domain/Board.java
@@ -3,6 +3,7 @@ package com.yeojeong.application.domain.board.board.domain;
 import com.yeojeong.application.domain.board.comment.domain.Comment;
 import com.yeojeong.application.config.util.BaseTime;
 import com.yeojeong.application.domain.member.domain.Member;
+import com.yeojeong.application.domain.planner.planner.domain.Planner;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -52,6 +53,9 @@ public class Board extends BaseTime {
 
     @OneToMany(mappedBy = "board", fetch = FetchType.LAZY)
     private List<Comment> comments;
+
+    @Column()
+    private Long plannerId;
 
     @Column(nullable = false)
     private Integer avgScore;

--- a/src/main/java/com/yeojeong/application/domain/board/board/presentation/AuthedBoardController.java
+++ b/src/main/java/com/yeojeong/application/domain/board/board/presentation/AuthedBoardController.java
@@ -43,7 +43,6 @@ public class AuthedBoardController {
             @Valid @RequestBody BoardRequest.Save dto
     ){
         Long memberId = SecurityUtil.getCurrentMemberId();
-
         return ResponseEntity.status(HttpStatus.CREATED).body(boardFacade.save(dto, memberId));
     }
 

--- a/src/main/java/com/yeojeong/application/domain/board/board/presentation/dto/BoardRequest.java
+++ b/src/main/java/com/yeojeong/application/domain/board/board/presentation/dto/BoardRequest.java
@@ -2,18 +2,32 @@ package com.yeojeong.application.domain.board.board.presentation.dto;
 
 import com.yeojeong.application.domain.board.board.domain.Board;
 import com.yeojeong.application.domain.member.domain.Member;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
 public class BoardRequest {
 
     @Builder
     public record Save(
-            String locationName,
-            String formattedAddress,
-            String latitude,  // 위도
-            String longitude,  // 경도
+            @NotBlank// 도
             String title,
-            String body
+
+            @NotBlank
+            String body,
+
+            @NotBlank
+            String locationName,
+
+            @NotBlank
+            String formattedAddress,
+
+            @NotBlank
+            String latitude,
+
+            @NotBlank
+            String longitude,
+
+            Long plannerId
     ) {
         public static Board toEntity(Save dto, Member member) {
             return Board.builder()
@@ -25,19 +39,34 @@ public class BoardRequest {
                     .body(dto.body())
                     .view(0)
                     .commentCount(0)
-                    .member(member)
                     .avgScore(0)
+
+                    .member(member)
+                    .plannerId(dto.plannerId())
                     .build();
         }
     }
 
     public record Put(
-            String locationName,
-            String formattedAddress,
-            String latitude,  // 위도
-            String longitude,  // 경도
+            @NotBlank
             String title,
-            String body
+
+            @NotBlank
+            String body,
+
+            @NotBlank
+            String locationName,
+
+            @NotBlank
+            String formattedAddress,
+
+            @NotBlank
+            String latitude,
+
+            @NotBlank
+            String longitude,
+
+            Long plannerId
     ) {
         public static Board toEntity(Put dto) {
             return Board.builder()
@@ -47,6 +76,8 @@ public class BoardRequest {
                     .longitude(dto.longitude())
                     .title(dto.title())
                     .body(dto.body())
+
+                    .plannerId(dto.plannerId())
                     .build();
         }
     }

--- a/src/main/java/com/yeojeong/application/domain/board/board/presentation/dto/BoardResponse.java
+++ b/src/main/java/com/yeojeong/application/domain/board/board/presentation/dto/BoardResponse.java
@@ -74,6 +74,7 @@ public class BoardResponse {
             Integer commentCount,
 
             MemberInfo member,
+            Long planner,
             TimeInfo time
     ) {
         @Builder
@@ -102,10 +103,14 @@ public class BoardResponse {
                     .view(board.getView())
                     .avgScore(board.getAvgScore())
                     .commentCount(board.getCommentCount())
+
                     .member(MemberInfo.builder()
                             .userId(board.getMember().getId())
                             .nickname(board.getMember().getNickname())
                             .build())
+
+                    .planner(board.getPlannerId())
+
                     .time(TimeInfo.builder()
                             .createTime(board.getCreateAt())
                             .updateTime(board.getUpdateAt())


### PR DESCRIPTION
### 게시글에 PlannerId 조회가능하게 수정

ID 값을 연관 관계 없이 설정했습니다.
왜냐하면 연관 관계가 있게 되면 데이터를 불러오는 DTO가 너무 복잡해지며,
UX 적으로 데이터가 많을 시 게시글의 응답 시간이 너무 길어질거라 생각했습니다.
그래서 프론트 로직에서는 게시글의 저장된 PlannerId로 추가적으로 엔드포인트를 선언하여 하는 쪽으로 로직을 구성했습니다.

### 추가 작업
- 게시글 저장 및 수정 DTO에서 유효성 검사 로직 추가
- Json의 형식이 잘못되었을 때의 예외 처리
- DateTime의 값을 UnixTimeStamp로 변환하는 과정에서 생기는 예외 처리