### PR TITLE
UnixTime 삭제

### DIFF
--- a/src/main/java/com/yeojeong/application/domain/member/application/memberfacade/MemberFacade.java
+++ b/src/main/java/com/yeojeong/application/domain/member/application/memberfacade/MemberFacade.java
@@ -9,7 +9,7 @@ public interface MemberFacade {
     void save(MemberRequest.SaveMember dto);
     void delete(long id, MemberRequest.checkPassword dto);
 
-    MemberResponse.FindById patch(Long id, MemberRequest.Patch dto);
+    MemberResponse.FindById patch(Long id, MemberRequest.Put dto);
     MemberResponse.FindById patchPassword(Long id, MemberRequest.PatchPassword dto);
     MemberResponse.patchKey checkPassword(Long id, String password);
 

--- a/src/main/java/com/yeojeong/application/domain/member/application/memberfacade/implement/MemberFacadeImpl.java
+++ b/src/main/java/com/yeojeong/application/domain/member/application/memberfacade/implement/MemberFacadeImpl.java
@@ -72,12 +72,12 @@ public class MemberFacadeImpl implements MemberFacade {
 
     @Override
     @Transactional
-    public MemberResponse.FindById patch(Long id, MemberRequest.Patch dto) {
+    public MemberResponse.FindById patch(Long id, MemberRequest.Put dto) {
         Member savedEntity = memberService.findById(id);
         if(!redisAuthedService.checkKey(savedEntity.getUsername(), dto.key())) throw new AuthedException("인증이 되지 않은 사용자 입니다.");
         redisAuthedService.delete(dto.key());
 
-        Member entity = MemberRequest.Patch.toEntity(dto);
+        Member entity = MemberRequest.Put.toEntity(dto);
         savedEntity.patchMember(entity);
         Member rtnEntity = memberService.patch(savedEntity);
 

--- a/src/main/java/com/yeojeong/application/domain/member/presentation/AuthedMemberController.java
+++ b/src/main/java/com/yeojeong/application/domain/member/presentation/AuthedMemberController.java
@@ -129,7 +129,7 @@ public class AuthedMemberController {
     }
 
     @MethodTimer(method = "회원 정보 수정 호출")
-    @PatchMapping
+    @PutMapping
     @Operation(summary = "유저 정보 수정", description = "회원 정보를 수정합니다")
     @ApiResponses(
             value = {
@@ -138,8 +138,8 @@ public class AuthedMemberController {
                     @ApiResponse(responseCode = "403", description = "권한 없음"),
             }
     )
-    public ResponseEntity<MemberResponse.FindById> patchMember(@Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
-                                                               @Valid @RequestBody MemberRequest.Patch dto) {
+    public ResponseEntity<MemberResponse.FindById> putMember(@Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
+                                                               @Valid @RequestBody MemberRequest.Put dto) {
 
         Long id = SecurityUtil.getCurrentMemberId();
         return ResponseEntity.ok(memberFacade.patch(id, dto));

--- a/src/main/java/com/yeojeong/application/domain/member/presentation/dto/MemberRequest.java
+++ b/src/main/java/com/yeojeong/application/domain/member/presentation/dto/MemberRequest.java
@@ -20,7 +20,7 @@ public class MemberRequest {
     ){}
 
     @Schema(name = "유저 정보 수정")
-    public record Patch(
+    public record Put(
             @NotBlank
             String key,
 
@@ -32,7 +32,7 @@ public class MemberRequest {
             @Schema(example = "90", nullable = true)
             Integer age
     ) {
-        public static Member toEntity(Patch dto) {
+        public static Member toEntity(Put dto) {
             return Member.builder()
                     .nickname(dto.nickname)
                     .age(dto.age)

--- a/src/main/java/com/yeojeong/application/domain/planner/location/domain/Location.java
+++ b/src/main/java/com/yeojeong/application/domain/planner/location/domain/Location.java
@@ -51,8 +51,7 @@ public class Location extends BaseTime {
     private Planner planner;
 
     public void update(LocationRequest.Put dto) {
-        LocalDateTime localDateTime = LocalDateTime.of(dto.year(), dto.month(), dto.day(), dto.hour(), dto.minute());
-        this.unixTime = Timestamp.valueOf(localDateTime).getTime();
+        this.unixTime = dto.unixTime();
 
         this.travelTime = dto.travelTime();
         this.transportation = dto.transportation();

--- a/src/main/java/com/yeojeong/application/domain/planner/location/domain/LocationRepository.java
+++ b/src/main/java/com/yeojeong/application/domain/planner/location/domain/LocationRepository.java
@@ -8,6 +8,5 @@ import java.util.List;
 
 public interface LocationRepository extends JpaRepository<Location, Long> {
     List<Location> findAllByPlannerIdOrderByUnixTime(Long plannerId);
-
     void deleteByPlannerId(Long plannerId);
 }

--- a/src/main/java/com/yeojeong/application/domain/planner/location/presentation/dto/LocationRequest.java
+++ b/src/main/java/com/yeojeong/application/domain/planner/location/presentation/dto/LocationRequest.java
@@ -8,23 +8,13 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
-import java.sql.Timestamp;
-import java.time.LocalDateTime;
-
 public class LocationRequest {
     @Builder
     @Schema(name = "장소 작성")
     public record Save(
             @NotNull
-            Integer year,
-            @NotNull
-            Integer month,
-            @NotNull
-            Integer day,
-            @NotNull
-            Integer hour,
-            @NotNull
-            Integer minute,
+            Long unixTime,
+
             @Min(0)
             Integer travelTime,
 
@@ -33,17 +23,17 @@ public class LocationRequest {
 
             @NotBlank
             String place,
+
             @NotBlank
             String address,
+
             String phoneNumber,
 
             String memo
     ){
         public static Location toEntity (Save dto, Planner planner) {
-            Long unixTime = returnUnixTime(dto.year(), dto.month(), dto.day(), dto.hour(), dto.minute());
-
             return Location.builder()
-                    .unixTime(unixTime)
+                    .unixTime(dto.unixTime())
                     .travelTime(dto.travelTime())
 
                     .transportation(dto.transportation())
@@ -63,15 +53,8 @@ public class LocationRequest {
     @Schema(name = "장소 수정")
     public record Put(
             @NotNull
-            Integer year,
-            @NotNull
-            Integer month,
-            @NotNull
-            Integer day,
-            @NotNull
-            Integer hour,
-            @NotNull
-            Integer minute,
+            Long unixTime,
+
             @Min(0)
             Integer travelTime,
 
@@ -82,16 +65,12 @@ public class LocationRequest {
             String place,
             @NotBlank
             String address,
+
             String phoneNumber,
 
             String memo
     ){
 
-    }
-
-    private static Long returnUnixTime(Integer year, Integer month, Integer day, Integer hour, Integer minute) {
-        LocalDateTime localDateTime = LocalDateTime.of(year, month, day, hour, minute);
-        return Timestamp.valueOf(localDateTime).getTime();
     }
 
 }

--- a/src/main/java/com/yeojeong/application/domain/planner/location/presentation/dto/LocationResponse.java
+++ b/src/main/java/com/yeojeong/application/domain/planner/location/presentation/dto/LocationResponse.java
@@ -4,45 +4,29 @@ import com.yeojeong.application.domain.planner.location.domain.Location;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.util.TimeZone;
-
 public class LocationResponse {
     @Builder
     @Schema(name = "장소 조회")
     public record FindById(
             Long id,
             Integer travelTime,
-
-            Integer year,
-            Integer month,
-            Integer day,
-
-            Integer hour,
-            Integer minute,
-
+            Long unixTime,
             String place,
             String address,
-            String memo
+            String memo,
+            Long plannerId
     ) {
         public static FindById toDto(Location entity) {
-            LocalDateTime localDateTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(entity.getUnixTime()), TimeZone.getDefault().toZoneId());
             return FindById.builder()
                     .id(entity.getId())
 
                     .travelTime(entity.getTravelTime())
-
-                    .year(localDateTime.getYear())
-                    .month(localDateTime.getMonthValue())
-                    .day(localDateTime.getDayOfMonth())
-
-                    .hour(localDateTime.getHour())
-                    .minute(localDateTime.getMinute())
+                    .unixTime(entity.getUnixTime())
 
                     .place(entity.getPlace())
                     .address(entity.getAddress())
                     .memo(entity.getMemo())
+                    .plannerId(entity.getPlanner().getId())
                     .build();
         }
     }


### PR DESCRIPTION
프론트 로직 변경으로 UnixTime을 삭제했습니다!

## 변경 내용 및 추가 작업 사항
### 프론트
- location 작성, 호출 unix로 변환, 복호화
- planner 개별 CRUD
- location UD
- 댓글 수정

### 백엔드
- location 작성, 호출 시 unix로 주고 받기
- 날짜 범위를 받았을 때 해당 날짜의 location 받기
- location 정보로 planner 정보 조회
- board planner 정보 포함하게 수정
- 댓글 수정