### PR TITLE
날짜를 기준으로 location 정보 불러오는 엔드포인트 생성

### DIFF
--- a/src/main/java/com/yeojeong/application/domain/member/application/memberfacade/MemberFacade.java
+++ b/src/main/java/com/yeojeong/application/domain/member/application/memberfacade/MemberFacade.java
@@ -4,18 +4,21 @@ import com.yeojeong.application.domain.member.presentation.dto.MemberRequest;
 import com.yeojeong.application.domain.member.presentation.dto.MemberResponse;
 import org.springframework.data.domain.Page;
 
+import java.util.List;
+
 public interface MemberFacade {
     MemberResponse.FindById findById(Long id);
     void save(MemberRequest.SaveMember dto);
-    void delete(long id, MemberRequest.checkPassword dto);
+    void delete(Long id, MemberRequest.checkPassword dto);
 
     MemberResponse.FindById patch(Long id, MemberRequest.Put dto);
     MemberResponse.FindById patchPassword(Long id, MemberRequest.PatchPassword dto);
     MemberResponse.patchKey checkPassword(Long id, String password);
 
-    Page<MemberResponse.BoardInfo> findBoardById(long id, int page);
-    Page<MemberResponse.CommentInfo> findCommentById(long id, int page);
-    Page<MemberResponse.PlannerInfo> findPlannerById(long id, int page);
+    Page<MemberResponse.BoardInfo> findBoardById(Long id, int page);
+    Page<MemberResponse.CommentInfo> findCommentById(Long id, int page);
+    Page<MemberResponse.PlannerInfo> findPlannerById(Long id, int page);
+    List<MemberResponse.LocationInfo> findLocationByDate(Long memberId, Long start, Long end);
 
     void findPassword(String username, String email);
     void findUsernameByEmail(String email);

--- a/src/main/java/com/yeojeong/application/domain/member/application/memberfacade/MemberFacade.java
+++ b/src/main/java/com/yeojeong/application/domain/member/application/memberfacade/MemberFacade.java
@@ -9,7 +9,7 @@ import java.util.List;
 public interface MemberFacade {
     MemberResponse.FindById findById(Long id);
     void save(MemberRequest.SaveMember dto);
-    void delete(Long id, MemberRequest.checkPassword dto);
+    void delete(Long id, MemberRequest.Delete dto);
 
     MemberResponse.FindById patch(Long id, MemberRequest.Put dto);
     MemberResponse.FindById patchPassword(Long id, MemberRequest.PatchPassword dto);

--- a/src/main/java/com/yeojeong/application/domain/member/application/memberfacade/implement/MemberFacadeImpl.java
+++ b/src/main/java/com/yeojeong/application/domain/member/application/memberfacade/implement/MemberFacadeImpl.java
@@ -15,6 +15,8 @@ import com.yeojeong.application.domain.member.domain.RedisAuthed;
 import com.yeojeong.application.domain.member.domain.Member;
 import com.yeojeong.application.domain.member.presentation.dto.MemberRequest;
 import com.yeojeong.application.domain.member.presentation.dto.MemberResponse;
+import com.yeojeong.application.domain.planner.location.application.locationservice.LocationService;
+import com.yeojeong.application.domain.planner.location.domain.Location;
 import com.yeojeong.application.domain.planner.planner.application.plannerservice.PlannerService;
 import com.yeojeong.application.domain.planner.planner.domain.Planner;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +25,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Random;
 import java.util.UUID;
 
@@ -36,6 +39,7 @@ public class MemberFacadeImpl implements MemberFacade {
     private final BoardService boardService;
     private final CommentService commentService;
     private final PlannerService plannerService;
+    private final LocationService locationService;
 
     private final EmailManager emailManager;
     private final PasswordEncoder passwordEncoder;
@@ -60,7 +64,7 @@ public class MemberFacadeImpl implements MemberFacade {
 
     @Override
     @Transactional
-    public void delete(long id, MemberRequest.checkPassword dto) {
+    public void delete(Long id, MemberRequest.checkPassword dto) {
         Member savedEntity = memberService.findById(id);
 
         String savedPassword = savedEntity.getPassword();
@@ -117,21 +121,26 @@ public class MemberFacadeImpl implements MemberFacade {
     }
 
     @Override
-    public Page<MemberResponse.BoardInfo> findBoardById(long id, int page) {
+    public Page<MemberResponse.BoardInfo> findBoardById(Long id, int page) {
         Page<Board> savedBoardPage = boardService.findByMember(id, page);
         return savedBoardPage.map(MemberResponse.BoardInfo::toDto);
     }
 
     @Override
-    public Page<MemberResponse.CommentInfo> findCommentById(long id, int page) {
+    public Page<MemberResponse.CommentInfo> findCommentById(Long id, int page) {
         Page<Comment> savedCommentPage = commentService.findByMemberId(id, page);
         return savedCommentPage.map(MemberResponse.CommentInfo::toDto);
     }
 
     @Override
-    public Page<MemberResponse.PlannerInfo> findPlannerById(long id, int page) {
+    public Page<MemberResponse.PlannerInfo> findPlannerById(Long id, int page) {
         Page<Planner> savedPlannerPage = plannerService.findByMemberId(id, page);
         return savedPlannerPage.map(MemberResponse.PlannerInfo::toDto);
+    }
+
+    public List<MemberResponse.LocationInfo> findLocationByDate(Long id, Long start, Long end) {
+        List<Location> savedLocationList = locationService.findByMemberAndDate(id, start, end);
+        return savedLocationList.stream().map(MemberResponse.LocationInfo::toDto).toList();
     }
 
 

--- a/src/main/java/com/yeojeong/application/domain/member/application/memberfacade/implement/MemberFacadeImpl.java
+++ b/src/main/java/com/yeojeong/application/domain/member/application/memberfacade/implement/MemberFacadeImpl.java
@@ -2,7 +2,6 @@ package com.yeojeong.application.domain.member.application.memberfacade.implemen
 
 import com.yeojeong.application.config.exception.AuthedException;
 import com.yeojeong.application.config.exception.NotFoundDataException;
-import com.yeojeong.application.config.exception.RequestDataException;
 import com.yeojeong.application.domain.board.board.application.boardservice.BoardService;
 import com.yeojeong.application.domain.board.board.domain.Board;
 import com.yeojeong.application.domain.board.comment.application.commentservice.CommentService;
@@ -64,7 +63,7 @@ public class MemberFacadeImpl implements MemberFacade {
 
     @Override
     @Transactional
-    public void delete(Long id, MemberRequest.checkPassword dto) {
+    public void delete(Long id, MemberRequest.Delete dto) {
         Member savedEntity = memberService.findById(id);
         if(!redisAuthedService.checkKey(savedEntity.getUsername(), dto.key())) throw new AuthedException("인증이 되지 않은 사용자 입니다.");
         redisAuthedService.delete(dto.key());

--- a/src/main/java/com/yeojeong/application/domain/member/application/memberfacade/implement/MemberFacadeImpl.java
+++ b/src/main/java/com/yeojeong/application/domain/member/application/memberfacade/implement/MemberFacadeImpl.java
@@ -66,10 +66,8 @@ public class MemberFacadeImpl implements MemberFacade {
     @Transactional
     public void delete(Long id, MemberRequest.checkPassword dto) {
         Member savedEntity = memberService.findById(id);
-
-        String savedPassword = savedEntity.getPassword();
-        String takenPassword = dto.password();
-        if(!passwordEncoder.matches(takenPassword, savedPassword)) throw new RequestDataException("비밀번호가 일치하지 않습니다.");
+        if(!redisAuthedService.checkKey(savedEntity.getUsername(), dto.key())) throw new AuthedException("인증이 되지 않은 사용자 입니다.");
+        redisAuthedService.delete(dto.key());
 
         memberService.delete(savedEntity);
     }

--- a/src/main/java/com/yeojeong/application/domain/member/presentation/AuthedMemberController.java
+++ b/src/main/java/com/yeojeong/application/domain/member/presentation/AuthedMemberController.java
@@ -15,9 +15,12 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -90,6 +93,20 @@ public class AuthedMemberController {
 
         Long id = SecurityUtil.getCurrentMemberId();
         return ResponseEntity.ok(memberFacade.findPlannerById(id, page));
+    }
+
+    @MethodTimer(method = "날짜 범위에 작성된 장소 조회")
+    @GetMapping("/locations")
+    @Operation(summary = "날짜 범위에 대한 장소를 조회", description = "날찌 범위에 작성된 장소를 모두 조회합니다.")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "날짜 범위에 대한 장소 조회 완료"),
+                    @ApiResponse(responseCode = "403", description = "권한 없음")
+            }
+    )
+    public ResponseEntity<List<MemberResponse.LocationInfo>> findLocationByDate(@RequestParam("start") Long start, @RequestParam("end") Long end) {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        return ResponseEntity.status(HttpStatus.OK).body(memberFacade.findLocationByDate(memberId, start, end));
     }
 
     @MethodTimer(method = "회원 탈퇴 호출")

--- a/src/main/java/com/yeojeong/application/domain/member/presentation/AuthedMemberController.java
+++ b/src/main/java/com/yeojeong/application/domain/member/presentation/AuthedMemberController.java
@@ -120,7 +120,7 @@ public class AuthedMemberController {
             }
     )
     public ResponseEntity<Void> deleteByUserId(@Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
-                                                 @Valid @RequestBody MemberRequest.checkPassword dto) {
+                                                 @Valid @RequestBody MemberRequest.Delete dto) {
 
         Long id = SecurityUtil.getCurrentMemberId();
         memberFacade.delete(id, dto);
@@ -139,7 +139,7 @@ public class AuthedMemberController {
             }
     )
     public ResponseEntity<MemberResponse.patchKey> checkPassword(@Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
-                                              @Valid @RequestBody MemberRequest.checkPassword dto) {
+                                              @Valid @RequestBody MemberRequest.CheckPassword dto) {
 
         Long id = SecurityUtil.getCurrentMemberId();
         return ResponseEntity.ok(memberFacade.checkPassword(id, dto.password()));

--- a/src/main/java/com/yeojeong/application/domain/member/presentation/dto/MemberRequest.java
+++ b/src/main/java/com/yeojeong/application/domain/member/presentation/dto/MemberRequest.java
@@ -58,9 +58,23 @@ public class MemberRequest {
             String password
     ) {}
 
-    public record checkPassword(
+    public record Delete(
             @NotBlank
             String key
+    ) {}
+
+    public record CheckPassword(
+            @NotBlank @Size(min = 8, max = 30)
+            @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[0-9])\\S+$", // 비밀번호 정규식
+                    message = "비밀번호는 영문(대,소문자)과 숫자가 적어도 1개 이상씩 포함되어야 합니다")
+            @Schema(example = "1q2w3e4r")
+            String checkPassword,
+
+            @NotBlank @Size(min = 8, max = 30)
+            @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[0-9])\\S+$", // 비밀번호 정규식
+                    message = "비밀번호는 영문(대,소문자)과 숫자가 적어도 1개 이상씩 포함되어야 합니다")
+            @Schema(example = "1q2w3e4r")
+            String password
     ) {}
 
     @Schema(name = "이메일 인증 코드")

--- a/src/main/java/com/yeojeong/application/domain/member/presentation/dto/MemberRequest.java
+++ b/src/main/java/com/yeojeong/application/domain/member/presentation/dto/MemberRequest.java
@@ -59,11 +59,8 @@ public class MemberRequest {
     ) {}
 
     public record checkPassword(
-            @NotBlank @Size(min = 8, max = 30)
-            @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[0-9])\\S+$", // 비밀번호 정규식
-                    message = "비밀번호는 영문(대,소문자)과 숫자가 적어도 1개 이상씩 포함되어야 합니다")
-            @Schema(example = "1q2w3e4r")
-            String password
+            @NotBlank
+            String key
     ) {}
 
     @Schema(name = "이메일 인증 코드")

--- a/src/main/java/com/yeojeong/application/domain/member/presentation/dto/MemberResponse.java
+++ b/src/main/java/com/yeojeong/application/domain/member/presentation/dto/MemberResponse.java
@@ -4,6 +4,7 @@ import com.yeojeong.application.domain.board.board.domain.Board;
 import com.yeojeong.application.domain.board.board.presentation.dto.BoardResponse;
 import com.yeojeong.application.domain.board.comment.domain.Comment;
 import com.yeojeong.application.domain.member.domain.Member;
+import com.yeojeong.application.domain.planner.location.domain.Location;
 import com.yeojeong.application.domain.planner.planner.domain.Planner;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
@@ -171,4 +172,29 @@ public class MemberResponse {
     public record patchKey(
             String key
     ) {}
+
+    @Builder
+    public record LocationInfo(
+            Long id,
+            Integer travelTime,
+            Long unixTime,
+            String place,
+            String address,
+            String memo,
+            Long plannerId
+    ) {
+        public static LocationInfo toDto(Location location) {
+            return LocationInfo.builder()
+                    .id(location.getId())
+
+                    .travelTime(location.getTravelTime())
+                    .unixTime(location.getUnixTime())
+
+                    .place(location.getPlace())
+                    .address(location.getAddress())
+                    .memo(location.getMemo())
+                    .plannerId(location.getPlanner().getId())
+                    .build();
+        }
+    }
 }

--- a/src/main/java/com/yeojeong/application/domain/planner/location/application/locationfacade/LocationFacade.java
+++ b/src/main/java/com/yeojeong/application/domain/planner/location/application/locationfacade/LocationFacade.java
@@ -6,9 +6,9 @@ import com.yeojeong.application.domain.planner.location.presentation.dto.Locatio
 import java.util.List;
 
 public interface LocationFacade {
-    LocationResponse.FindById save(LocationRequest.Save dto, Long plannerId);
-    void delete(Long id);
-    LocationResponse.FindById update(LocationRequest.Put dto, Long id);
-    LocationResponse.FindById findById(Long id);
-    List<LocationResponse.FindById> findByPlannerId(Long plannerId);
+    LocationResponse.FindById save(LocationRequest.Save dto, Long plannerId, Long memberId);
+    void delete(Long id, Long memberId);
+    LocationResponse.FindById update(LocationRequest.Put dto, Long id, Long memberId);
+    LocationResponse.FindById findById(Long id, Long memberId);
+    List<LocationResponse.FindById> findByPlannerId(Long plannerId, Long memberId);
 }

--- a/src/main/java/com/yeojeong/application/domain/planner/location/application/locationservice/LocationService.java
+++ b/src/main/java/com/yeojeong/application/domain/planner/location/application/locationservice/LocationService.java
@@ -9,6 +9,7 @@ public interface LocationService {
     Location findById(Long id);
     Location update(Location entity);
     void delete(Location entity);
-    List<Location> findByPlannerId(Long plannerId);
+    List<Location> findByPlannerId(Long plannerId, Long memberId);
     void deleteByPlannerId(Long plannerId);
+    List<Location> findByMemberAndDate(Long id, Long start, Long end);
 }

--- a/src/main/java/com/yeojeong/application/domain/planner/location/application/locationservice/implement/LocationServiceImpl.java
+++ b/src/main/java/com/yeojeong/application/domain/planner/location/application/locationservice/implement/LocationServiceImpl.java
@@ -42,7 +42,12 @@ public class LocationServiceImpl implements LocationService {
     }
 
     @Override
-    public List<Location> findByPlannerId(Long plannerId) {
-        return locationRepository.findAllByPlannerIdOrderByUnixTime(plannerId);
+    public List<Location> findByMemberAndDate(Long memberId, Long start, Long end) {
+        return locationRepository.findByMemberAndDate(memberId, start, end);
+    }
+
+    @Override
+    public List<Location> findByPlannerId(Long plannerId, Long memberId) {
+        return locationRepository.findByMemberAndPlanner(memberId, plannerId);
     }
 }

--- a/src/main/java/com/yeojeong/application/domain/planner/location/domain/Location.java
+++ b/src/main/java/com/yeojeong/application/domain/planner/location/domain/Location.java
@@ -1,6 +1,7 @@
 package com.yeojeong.application.domain.planner.location.domain;
 
 import com.yeojeong.application.config.util.BaseTime;
+import com.yeojeong.application.domain.member.domain.Member;
 import com.yeojeong.application.domain.planner.location.presentation.dto.LocationRequest;
 import com.yeojeong.application.domain.planner.planner.domain.Planner;
 import jakarta.persistence.*;
@@ -50,17 +51,21 @@ public class Location extends BaseTime {
     @JoinColumn(name = "planner_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Planner planner;
 
-    public void update(LocationRequest.Put dto) {
-        this.unixTime = dto.unixTime();
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Member member;
 
-        this.travelTime = dto.travelTime();
-        this.transportation = dto.transportation();
-        this.transportationNote = dto.transportationNote();
+    public void update(Location updateEntity) {
+        this.unixTime = updateEntity.getUnixTime();
 
-        this.place = dto.place();
-        this.address = dto.address();
-        this.phoneNumber = dto.phoneNumber();
-        this.memo = dto.memo();
+        this.travelTime = updateEntity.getTravelTime();
+        this.transportation = updateEntity.getTransportation();
+        this.transportationNote = updateEntity.getTransportationNote();
+
+        this.place = updateEntity.getPlace();
+        this.address = updateEntity.getAddress();
+        this.phoneNumber = updateEntity.getPhoneNumber();
+        this.memo = updateEntity.getMemo();
     }
 
 

--- a/src/main/java/com/yeojeong/application/domain/planner/location/domain/LocationRepository.java
+++ b/src/main/java/com/yeojeong/application/domain/planner/location/domain/LocationRepository.java
@@ -7,6 +7,11 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface LocationRepository extends JpaRepository<Location, Long> {
-    List<Location> findAllByPlannerIdOrderByUnixTime(Long plannerId);
     void deleteByPlannerId(Long plannerId);
+
+    @Query("SELECT l FROM Location l WHERE l.member.id = :memberId AND l.planner.id = :plannerId ORDER BY l.unixTime")
+    List<Location> findByMemberAndPlanner(@Param("memberId") Long memberId, @Param("plannerId") Long plannerId);
+
+    @Query("SELECT l FROM Location l WHERE l.member.id = :memberId AND l.unixTime BETWEEN :start AND :end ORDER BY l.unixTime")
+    List<Location> findByMemberAndDate(@Param("memberId") Long memberId, @Param("start") Long start, @Param("end") Long end);
 }

--- a/src/main/java/com/yeojeong/application/domain/planner/location/presentation/AuthedLocationController.java
+++ b/src/main/java/com/yeojeong/application/domain/planner/location/presentation/AuthedLocationController.java
@@ -4,6 +4,7 @@ import com.yeojeong.application.config.util.customannotation.MethodTimer;
 import com.yeojeong.application.domain.planner.location.application.locationfacade.LocationFacade;
 import com.yeojeong.application.domain.planner.location.presentation.dto.LocationRequest;
 import com.yeojeong.application.domain.planner.location.presentation.dto.LocationResponse;
+import com.yeojeong.application.security.config.SecurityUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -29,6 +30,7 @@ public class AuthedLocationController {
 
     private final LocationFacade locationFacade;
 
+
     @MethodTimer(method = " 장소 작성")
     @PostMapping("/{plannerId}")
     @Operation(summary = "장소 작성", description = "Planner 의 장소를 기록합니다.")
@@ -41,7 +43,8 @@ public class AuthedLocationController {
     public ResponseEntity<LocationResponse.FindById> save(@PathVariable("plannerId") Long plannerId,
                                                          @Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
                                                          @Valid @RequestBody LocationRequest.Save dto) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(locationFacade.save(dto, plannerId));
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        return ResponseEntity.status(HttpStatus.CREATED).body(locationFacade.save(dto, plannerId, memberId));
     }
 
     @MethodTimer(method = " 장소 수정")
@@ -56,7 +59,8 @@ public class AuthedLocationController {
     public ResponseEntity<LocationResponse.FindById> put(@PathVariable("id") Long id,
                                                           @Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
                                                           @Valid @RequestBody LocationRequest.Put dto) {
-        return ResponseEntity.status(HttpStatus.OK).body(locationFacade.update(dto, id));
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        return ResponseEntity.status(HttpStatus.OK).body(locationFacade.update(dto, id, memberId));
     }
 
     @MethodTimer(method = " 장소 삭제")
@@ -69,7 +73,8 @@ public class AuthedLocationController {
             }
     )
     public ResponseEntity<Void> delete(@PathVariable("id") Long id) {
-        locationFacade.delete(id);
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        locationFacade.delete(id, memberId);
         return ResponseEntity.noContent().build();
     }
 
@@ -83,11 +88,12 @@ public class AuthedLocationController {
             }
     )
     public ResponseEntity<LocationResponse.FindById> findById(@PathVariable("id") Long id) {
-        return ResponseEntity.status(HttpStatus.OK).body(locationFacade.findById(id));
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        return ResponseEntity.status(HttpStatus.OK).body(locationFacade.findById(id, memberId));
     }
 
     @MethodTimer(method = "플래너에 작성된 장소 조회")
-    @GetMapping("/get/{plannerId}")
+    @GetMapping("/planners/{plannerId}")
     @Operation(summary = "플래너에 대한 장소를 조회", description = "Planner의 장소를 모두 조회합니다.")
     @ApiResponses(
             value = {
@@ -96,6 +102,7 @@ public class AuthedLocationController {
             }
     )
     public ResponseEntity<List<LocationResponse.FindById>> findByPlannerId (@PathVariable("plannerId") Long plannerId) {
-        return ResponseEntity.status(HttpStatus.OK).body(locationFacade.findByPlannerId(plannerId));
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        return ResponseEntity.status(HttpStatus.OK).body(locationFacade.findByPlannerId(plannerId, memberId));
     }
 }

--- a/src/main/java/com/yeojeong/application/domain/planner/location/presentation/dto/LocationRequest.java
+++ b/src/main/java/com/yeojeong/application/domain/planner/location/presentation/dto/LocationRequest.java
@@ -1,5 +1,6 @@
 package com.yeojeong.application.domain.planner.location.presentation.dto;
 
+import com.yeojeong.application.domain.member.domain.Member;
 import com.yeojeong.application.domain.planner.location.domain.Location;
 import com.yeojeong.application.domain.planner.planner.domain.Planner;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -31,7 +32,7 @@ public class LocationRequest {
 
             String memo
     ){
-        public static Location toEntity (Save dto, Planner planner) {
+        public static Location toEntity (Save dto, Planner planner, Member member) {
             return Location.builder()
                     .unixTime(dto.unixTime())
                     .travelTime(dto.travelTime())
@@ -45,6 +46,7 @@ public class LocationRequest {
                     .memo(dto.memo())
 
                     .planner(planner)
+                    .member(member)
                     .build();
         }
     }
@@ -70,7 +72,21 @@ public class LocationRequest {
 
             String memo
     ){
+        public static Location toEntity (Put dto) {
+            return Location.builder()
+                    .unixTime(dto.unixTime())
+                    .travelTime(dto.travelTime())
 
+                    .transportation(dto.transportation())
+                    .transportationNote(dto.transportationNote())
+
+                    .place(dto.place())
+                    .address(dto.address())
+                    .phoneNumber(dto.phoneNumber())
+                    .memo(dto.memo())
+
+                    .build();
+        }
     }
 
 }

--- a/src/main/java/com/yeojeong/application/domain/planner/planner/application/plannerfacade/implement/PlannerFacadeImpl.java
+++ b/src/main/java/com/yeojeong/application/domain/planner/planner/application/plannerfacade/implement/PlannerFacadeImpl.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Objects;
 
 @Service
-@Slf4j
 @RequiredArgsConstructor
 public class PlannerFacadeImpl implements PlannerFacade {
     private final MemberService memberService;
@@ -42,12 +41,12 @@ public class PlannerFacadeImpl implements PlannerFacade {
     public PlannerResponse.FindById update(Long id, PlannerRequest.Put dto, Long memberId) {
         Planner savedEntity = plannerService.findById(id);
         checkMember(savedEntity, memberId);
+        Planner entity = PlannerRequest.Put.toEntity(dto);
 
-        savedEntity.update(dto);
-
+        savedEntity.update(entity);
         Planner rtnEntity = plannerService.update(savedEntity);
 
-        List<Location> locationList = locationService.findByPlannerId(id);
+        List<Location> locationList = locationService.findByPlannerId(id, memberId);
         List<LocationResponse.FindById> locationFindByIdList = locationList.stream().map(LocationResponse.FindById::toDto).toList();
 
         return PlannerResponse.FindById.toDto(rtnEntity, locationFindByIdList);
@@ -67,7 +66,7 @@ public class PlannerFacadeImpl implements PlannerFacade {
     public PlannerResponse.FindById findById(Long id, Long memberId) {
         Planner savedEntity = plannerService.findById(id);
         checkMember(savedEntity, memberId);
-        List<Location> locationList = locationService.findByPlannerId(id);
+        List<Location> locationList = locationService.findByPlannerId(id, memberId);
         List<LocationResponse.FindById> locationFindByIdList = locationList.stream().map(LocationResponse.FindById::toDto).toList();
 
         return PlannerResponse.FindById.toDto(savedEntity, locationFindByIdList);

--- a/src/main/java/com/yeojeong/application/domain/planner/planner/domain/Planner.java
+++ b/src/main/java/com/yeojeong/application/domain/planner/planner/domain/Planner.java
@@ -41,10 +41,10 @@ public class Planner extends BaseTime {
     @JoinColumn(name = "member_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Member member;
 
-    public void update(PlannerRequest.Put dto) {
-        title = dto.title();
-        personnel = dto.personnel();
-        subTitle = dto.subTitle();
+    public void update(Planner updateEntity) {
+        title = updateEntity.getTitle();
+        personnel = updateEntity.getPersonnel();
+        subTitle = updateEntity.getSubTitle();
     }
 
     public void addLocation(){

--- a/src/main/java/com/yeojeong/application/domain/planner/planner/presentation/AuthedPlannerController.java
+++ b/src/main/java/com/yeojeong/application/domain/planner/planner/presentation/AuthedPlannerController.java
@@ -82,8 +82,8 @@ public class AuthedPlannerController {
     @Operation(summary = "플래너 호출")
     @ApiResponses(
             value = {
-                    @ApiResponse(responseCode = "204", description = "플래너 삭제 성공"),
-                    @ApiResponse(responseCode = "400", description = "플래너 삭제 실패")
+                    @ApiResponse(responseCode = "200", description = "플래너 호출 성공"),
+                    @ApiResponse(responseCode = "400", description = "플래너 호출 실패")
             }
     )
     public ResponseEntity<PlannerResponse.FindById> findById(@PathVariable("id") Long id){

--- a/src/main/java/com/yeojeong/application/security/config/JwtProvider.java
+++ b/src/main/java/com/yeojeong/application/security/config/JwtProvider.java
@@ -18,18 +18,14 @@ public class JwtProvider {
     public String SECRET;
 
     //JWT Token는 1시간의 유효기간을 가짐
-    public final int JWT_EXPIRATION_TIME = 60 * 60 * 1000;
+    static public final int JWT_EXPIRATION_TIME = 60 * 60 * 1000;
 
     //Refresh Token는 하루의 유효기간을 가짐
-    public final int REFRESH_EXPIRATION_TIME = 24 * 60 * 60 * 1000;
+    static public final int REFRESH_EXPIRATION_TIME = 24 * 60 * 60 * 1000;
+    static public final String REFRESH_HEADER_STRING = "Refresh";
 
-    //JWT Token의 재발급은 10번으로 제한
-    public final String TOKEN_PREFIX_JWT = "Bearer ";
-
-    // cookie 에서는 빈칸이 되지 않아서 빈칸을 삭제
-    public final String TOKEN_PREFIX_REFRESH = "Bearer.";
-    public final String JWT_HEADER_STRING = "Authorization";
-    public final String REFRESH_HEADER_STRING = "Refresh";
+    static public final String TOKEN_PREFIX_JWT = "Bearer ";
+    static public final String JWT_HEADER_STRING = "Authorization";
 
     public String createJwtToken(MemberDetails member) {
 
@@ -43,7 +39,7 @@ public class JwtProvider {
 
     }
 
-    public String createRefreshToken(MemberDetails member, long createTime) {
+    static public String createRefreshToken(MemberDetails member, String createTime) {
 
         String role = member.getAuthorities().stream().map(GrantedAuthority::getAuthority).toList().get(0);
 
@@ -51,7 +47,7 @@ public class JwtProvider {
                 .withExpiresAt(new Date(System.currentTimeMillis() + REFRESH_EXPIRATION_TIME))
                 .withClaim("id", member.getMemberId())
                 .withClaim("role", role)
-                .sign(Algorithm.HMAC512(String.valueOf(createTime + REFRESH_EXPIRATION_TIME)));
+                .sign(Algorithm.HMAC512(createTime));
 
     }
 

--- a/src/main/java/com/yeojeong/application/security/config/refreshtoken/application/RefreshTokenFacade.java
+++ b/src/main/java/com/yeojeong/application/security/config/refreshtoken/application/RefreshTokenFacade.java
@@ -1,0 +1,11 @@
+package com.yeojeong.application.security.config.refreshtoken.application;
+
+
+import com.yeojeong.application.domain.member.presentation.dto.MemberDetails;
+import jakarta.servlet.http.Cookie;
+
+public interface RefreshTokenFacade {
+    MemberDetails getMemberDetailsByRefreshToken(Cookie[] cookies);
+    Cookie createNewRefreshTokenCookie(MemberDetails memberDetails);
+    String createNewJwtToken(MemberDetails memberDetails);
+}

--- a/src/main/java/com/yeojeong/application/security/config/refreshtoken/application/RefreshTokenService.java
+++ b/src/main/java/com/yeojeong/application/security/config/refreshtoken/application/RefreshTokenService.java
@@ -1,16 +1,9 @@
 package com.yeojeong.application.security.config.refreshtoken.application;
 
-import com.yeojeong.application.domain.member.presentation.dto.MemberDetails;
 import com.yeojeong.application.security.config.refreshtoken.domain.RefreshToken;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 
 public interface RefreshTokenService {
     void save(RefreshToken data);
     RefreshToken findById(String token);
     void delete(RefreshToken token);
-    RefreshToken validRefresh(Cookie[] cookies, String token);
-    String createRefresh(Long memberId, MemberDetails member);
-    Cookie setRefreshCookie(String refreshToken);
 }

--- a/src/main/java/com/yeojeong/application/security/config/refreshtoken/application/implement/RefreshTokenFacadeImpl.java
+++ b/src/main/java/com/yeojeong/application/security/config/refreshtoken/application/implement/RefreshTokenFacadeImpl.java
@@ -1,0 +1,69 @@
+package com.yeojeong.application.security.config.refreshtoken.application.implement;
+
+import com.yeojeong.application.config.exception.AuthedException;
+import com.yeojeong.application.domain.member.domain.Member;
+import com.yeojeong.application.domain.member.presentation.dto.MemberDetails;
+import com.yeojeong.application.security.config.JwtProvider;
+import com.yeojeong.application.security.config.refreshtoken.application.RefreshTokenFacade;
+import com.yeojeong.application.security.config.refreshtoken.application.RefreshTokenService;
+import com.yeojeong.application.security.config.refreshtoken.domain.RefreshToken;
+import jakarta.servlet.http.Cookie;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenFacadeImpl implements RefreshTokenFacade {
+
+    private final RefreshTokenService refreshTokenService;
+    private final JwtProvider jwtProvider;
+
+    public MemberDetails getMemberDetailsByRefreshToken(Cookie[] cookies) {
+        String refreshToken = RefreshTokenFacadeImpl.getRefreshTokenByCookie(cookies);
+        RefreshToken refreshTokenEntity = refreshTokenService.findById(refreshToken);
+        refreshTokenService.delete(refreshTokenEntity);
+
+        Member member = jwtProvider.decodeToken(refreshToken, refreshTokenEntity.getKey());
+        return new MemberDetails(member);
+    }
+
+    public Cookie createNewRefreshTokenCookie(MemberDetails memberDetails) {
+        String newRefreshToken = RefreshTokenFacadeImpl.createRefreshToken(refreshTokenService, memberDetails);
+        return RefreshTokenFacadeImpl.createRefreshCookie(newRefreshToken);
+    }
+
+    public String createNewJwtToken(MemberDetails memberDetails) {
+        return jwtProvider.createJwtToken(memberDetails);
+    }
+
+    static public String createRefreshToken(RefreshTokenService refreshTokenService, MemberDetails member) {
+        String loginTime = Long.toString(System.currentTimeMillis());
+
+        String refreshToken = JwtProvider.createRefreshToken(member, loginTime);
+        RefreshToken saveToken = RefreshToken.builder()
+                .id(refreshToken)
+                .key(loginTime)
+                .ttl(JwtProvider.REFRESH_EXPIRATION_TIME / 1000)
+                .build();
+
+        refreshTokenService.save(saveToken);
+        return refreshToken;
+    }
+
+    static public Cookie createRefreshCookie(String refreshToken) {
+        Cookie refreshCookie = new Cookie(JwtProvider.REFRESH_HEADER_STRING, refreshToken);
+        refreshCookie.setAttribute("SameSite", "None");
+        refreshCookie.setHttpOnly(true);
+        refreshCookie.setPath("/");
+
+        return refreshCookie;
+    }
+
+    static public String getRefreshTokenByCookie(Cookie[] cookies) {
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals(JwtProvider.REFRESH_HEADER_STRING))
+                return cookie.getValue();
+        }
+        throw new AuthedException("Refresh token이 존재하지 않습니다.");
+    }
+}

--- a/src/main/java/com/yeojeong/application/security/config/refreshtoken/application/implement/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/yeojeong/application/security/config/refreshtoken/application/implement/RefreshTokenServiceImpl.java
@@ -1,28 +1,17 @@
 package com.yeojeong.application.security.config.refreshtoken.application.implement;
 
 import com.yeojeong.application.config.exception.AuthedException;
-import com.yeojeong.application.domain.member.presentation.dto.MemberDetails;
-import com.yeojeong.application.security.config.JwtProvider;
 import com.yeojeong.application.security.config.refreshtoken.domain.RefreshToken;
 import com.yeojeong.application.security.config.refreshtoken.domain.RefreshTokenRepository;
 import com.yeojeong.application.security.config.refreshtoken.application.RefreshTokenService;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
-
-
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RefreshTokenServiceImpl implements RefreshTokenService {
 
     private final RefreshTokenRepository refreshTokenRepository;
-    private final JwtProvider jwtProvider;
 
     @Override
     public void save(RefreshToken data) {
@@ -31,62 +20,12 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
 
     @Override
     public RefreshToken findById(String token) {
-        Optional<RefreshToken> savedOptionalRefreshToken = refreshTokenRepository.findById(token);
-        if(savedOptionalRefreshToken.isEmpty()) throw new AuthedException("Refresh Token 내용이 존재하지 않습니다.");
-
-        RefreshToken savedRefreshToken = savedOptionalRefreshToken.get();
-
-        return savedRefreshToken;
+        return refreshTokenRepository.findById(token)
+                .orElseThrow(() -> new AuthedException("Refresh Token의 값을 찾을 수 없습니다."));
     }
 
     @Override
     public void delete(RefreshToken token) {
         refreshTokenRepository.delete(token);
-    }
-
-    @Override
-    public RefreshToken validRefresh (Cookie[] cookies, String refreshTokenHeader) {
-        try {
-            for (Cookie cookie : cookies) {
-                if (cookie.getName().equals(jwtProvider.REFRESH_HEADER_STRING)) refreshTokenHeader = cookie.getValue();
-            }
-        } catch (Exception e) {
-            throw new AuthedException("Refresh Token 쿠키에 존재하지 않습니다.");
-        }
-
-        if (refreshTokenHeader == null) throw new AuthedException("Refresh Token 쿠키에 존재하지 않습니다.");
-
-        refreshTokenHeader = refreshTokenHeader.replace(jwtProvider.TOKEN_PREFIX_REFRESH, "");
-
-        RefreshToken savedRefreshToken = findById(refreshTokenHeader);
-
-        return savedRefreshToken;
-    }
-
-    @Override
-    public String createRefresh(Long memberId, MemberDetails member){
-
-        long loginTime = System.currentTimeMillis();
-        String refreshToken = jwtProvider.createRefreshToken(member, loginTime);
-
-        RefreshToken saveToken = RefreshToken.builder()
-                .id(refreshToken)
-                .expirationTime(loginTime + jwtProvider.REFRESH_EXPIRATION_TIME)
-                .ttl(jwtProvider.REFRESH_EXPIRATION_TIME / 1000)
-                .build();
-
-        refreshTokenRepository.save(saveToken);
-
-        return refreshToken;
-    }
-
-    @Override
-    public Cookie setRefreshCookie (String refreshToken) {
-        Cookie refreshCookie = new Cookie(jwtProvider.REFRESH_HEADER_STRING, jwtProvider.TOKEN_PREFIX_REFRESH + refreshToken);
-        refreshCookie.setAttribute("SameSite", "None");
-        refreshCookie.setHttpOnly(true);
-        refreshCookie.setPath("/");
-
-        return refreshCookie;
     }
 }

--- a/src/main/java/com/yeojeong/application/security/config/refreshtoken/domain/RefreshToken.java
+++ b/src/main/java/com/yeojeong/application/security/config/refreshtoken/domain/RefreshToken.java
@@ -11,7 +11,7 @@ import org.springframework.data.redis.core.TimeToLive;
 public class RefreshToken {
     @Id
     private String id;
-    private Long expirationTime;
+    private String key;
     @TimeToLive
     private long ttl;
 }

--- a/src/main/java/com/yeojeong/application/security/config/refreshtoken/presentation/RefreshController.java
+++ b/src/main/java/com/yeojeong/application/security/config/refreshtoken/presentation/RefreshController.java
@@ -1,14 +1,9 @@
 package com.yeojeong.application.security.config.refreshtoken.presentation;
 
-import com.auth0.jwt.JWT;
-import com.auth0.jwt.algorithms.Algorithm;
-import com.yeojeong.application.config.exception.AuthedException;
 import com.yeojeong.application.config.util.customannotation.MethodTimer;
 import com.yeojeong.application.domain.member.presentation.dto.MemberDetails;
 import com.yeojeong.application.security.config.JwtProvider;
-import com.yeojeong.application.security.config.SecurityUtil;
-import com.yeojeong.application.security.config.refreshtoken.application.RefreshTokenService;
-import com.yeojeong.application.security.config.refreshtoken.domain.RefreshToken;
+import com.yeojeong.application.security.config.refreshtoken.application.RefreshTokenFacade;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -18,7 +13,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -29,8 +23,8 @@ import org.springframework.web.bind.annotation.*;
 @Slf4j
 @RequiredArgsConstructor
 public class RefreshController {
-    private final RefreshTokenService refreshTokenService;
-    private final JwtProvider jwtProvider;
+
+    private final RefreshTokenFacade refreshTokenFacade;
 
     @MethodTimer(method = "리프레시 토큰 재발급")
     @Operation(summary = "리프레시 토큰 재발급")
@@ -45,25 +39,14 @@ public class RefreshController {
     public ResponseEntity<Void> refresh(
             HttpServletRequest request, HttpServletResponse response, Authentication authResult
     ){
-        String refreshTokenHeader = null;
         Cookie[] cookies = request.getCookies();
 
-        // refresh token 이 유효한지 확인 -> 제거
-        RefreshToken savedRefreshToken = refreshTokenService.validRefresh(cookies, refreshTokenHeader);
-        refreshTokenService.delete(savedRefreshToken);
+        MemberDetails memberDetails = refreshTokenFacade.getMemberDetailsByRefreshToken(cookies);
+        Cookie refreshCookie = refreshTokenFacade.createNewRefreshTokenCookie(memberDetails);
 
-        MemberDetails member = SecurityUtil.getCurrentMember(authResult);
-
-        // refresh token 을 새롭게 생성
-        String refreshToken = refreshTokenService.createRefresh(member.getMemberId(), member);
-
-        Cookie refreshCookie = refreshTokenService.setRefreshCookie(refreshToken);
-
-
-        String jwtToken = jwtProvider.createJwtToken(member);
-
-        response.addHeader(jwtProvider.JWT_HEADER_STRING, jwtProvider.TOKEN_PREFIX_JWT + jwtToken);
-        response.addHeader("Set-Cookie", refreshCookie.toString());
+        String jwtToken = refreshTokenFacade.createNewJwtToken(memberDetails);
+        response.addHeader(JwtProvider.JWT_HEADER_STRING, JwtProvider.TOKEN_PREFIX_JWT + jwtToken);
+        response.addCookie(refreshCookie);
 
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
@@ -73,26 +56,11 @@ public class RefreshController {
     @GetMapping("/access")
     @ApiResponses(
             value = {
-                    @ApiResponse(responseCode = "200", description = "access token 유효성 검사 성공"),
-                    @ApiResponse(responseCode = "400", description = "access token 유효성 검사 실패"),
-                    @ApiResponse(responseCode = "403", description = "권한 없음"),
+                    @ApiResponse(responseCode = "200", description = "유효한 토큰"),
+                    @ApiResponse(responseCode = "403", description = "유효하지 않은 토큰"),
             }
     )
-    public ResponseEntity<Boolean> access(
-            HttpServletRequest request, HttpServletResponse response
-    ){
-        String accessToken = request.getHeader(jwtProvider.JWT_HEADER_STRING);
-        if (accessToken == null) throw new AuthedException("Access Token 이 존재하지 않습니다.");
-
-        String token = accessToken.replace(jwtProvider.TOKEN_PREFIX_JWT, "");
-
-        Long userCode = null;
-        try {
-            userCode = JWT.require(Algorithm.HMAC512(jwtProvider.SECRET)).build().verify(token).getClaim("id").asLong();
-        } catch (Exception e) {
-            throw new AuthedException("Access Token 이 유효하지 않습니다.");
-        }
-
+    public ResponseEntity<Void> access() {
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/com/yeojeong/application/security/config/refreshtoken/presentation/RefreshController.java
+++ b/src/main/java/com/yeojeong/application/security/config/refreshtoken/presentation/RefreshController.java
@@ -25,7 +25,7 @@ import org.springframework.web.bind.annotation.*;
 
 
 @RestController
-@RequestMapping("/token")
+@RequestMapping("/tokens")
 @Slf4j
 @RequiredArgsConstructor
 public class RefreshController {

--- a/src/main/java/com/yeojeong/application/security/filter/JwtFilter.java
+++ b/src/main/java/com/yeojeong/application/security/filter/JwtFilter.java
@@ -5,7 +5,6 @@ import com.yeojeong.application.config.exception.response.ExceptionResponseSende
 import com.yeojeong.application.domain.member.presentation.dto.MemberDetails;
 import com.yeojeong.application.domain.member.domain.Member;
 import com.yeojeong.application.security.config.JwtProvider;
-import com.yeojeong.application.security.config.refreshtoken.application.RefreshTokenService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -25,20 +24,19 @@ import java.io.IOException;
 public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
-    private final RefreshTokenService refreshTokenService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
-        String jwtTokenHeader = request.getHeader(jwtProvider.JWT_HEADER_STRING);
+        String jwtTokenHeader = request.getHeader(JwtProvider.JWT_HEADER_STRING);
 
         if(jwtTokenHeader == null) {
             filterChain.doFilter(request, response);
             return;
         }
 
-        jwtTokenHeader = jwtTokenHeader.replace(jwtProvider.TOKEN_PREFIX_JWT, "");
+        jwtTokenHeader = jwtTokenHeader.replace(JwtProvider.TOKEN_PREFIX_JWT, "");
 
         try {
             Member jwtTokenMember = jwtProvider.decodeToken(jwtTokenHeader, jwtProvider.SECRET);

--- a/src/main/java/com/yeojeong/application/security/filter/SecurityFilter.java
+++ b/src/main/java/com/yeojeong/application/security/filter/SecurityFilter.java
@@ -37,7 +37,7 @@ public class SecurityFilter {
                 .sessionManagement(auth -> auth.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
                 .addFilterAt(new LoginFilter(authenticationManager, jwtProvider, refreshTokenService, memberChangeService), UsernamePasswordAuthenticationFilter.class)
-                .addFilterAfter(new JwtFilter(jwtProvider, refreshTokenService), LoginFilter.class)
+                .addFilterAfter(new JwtFilter(jwtProvider), LoginFilter.class)
 
                 .exceptionHandling(auth -> auth
                         .accessDeniedHandler(new CustomAccessDeniedHandler()))
@@ -46,6 +46,7 @@ public class SecurityFilter {
                         .requestMatchers("/members/authed/**").authenticated()
                         .requestMatchers("/boards/authed/**").authenticated()
                         .requestMatchers("/boards/comments/authed/**").authenticated()
+                        .requestMatchers("/tokens/access").authenticated()
                         .anyRequest().permitAll());
 
         return http.build();


### PR DESCRIPTION
## Feat
- 날짜를 기준으로 location 정보 불러오는 엔드포인트 생성
- location에 Member 정보 포함
- location, planner CRUD시 Member 정보 확인 안 하는 버그 수정
- 전체적인 로직 통일화

## Fix
- RefreshToken 재발급 버그 수정
- access의 내부 로직 삭제 -> JwtFilter에서 같은 로직 수행

## Refactor
- RefreshTokenFacade를 만들어 Controller의 의존성을 줄임
- RefreshTokenFacade에 static 메서드로 분리되어있던 RefreshToken 관련 로직을 하나의 class에 정리
- JwtProvider의 class 변수를 일부분 static으로 변경